### PR TITLE
Simplify dashboard to use predefined vendor list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,47 +151,26 @@ function renderPage() {
   <header>
     <div class="header-inner">
       <h1 class="app-title">Collaborative Security Dashboard</h1>
-      <div class="sub">Live UpGuard vendor scores across participating municipalities. Add domains below and refresh.</div>
+        <div class="sub">Live UpGuard vendor scores across participating municipalities.</div>
     </div>
   </header>
 
   <section class="panel">
-    <div class="toolbar">
-      <input id="vendors" class="input" type="text" placeholder="Add vendors: example.com, city.gov" />
-      <select id="sort" class="input" style="min-width:160px;">
-        <option value="desc">Sort: Highest score</option>
-        <option value="asc">Sort: Lowest score</option>
-        <option value="alpha">Sort: A–Z</option>
-      </select>
-      <button id="refresh" class="btn btn-primary">Refresh</button>
-      <button id="reset" class="btn btn-ghost">Reset</button>
-    </div>
+      <div class="toolbar">
+        <select id="sort" class="input" style="min-width:160px;">
+          <option value="desc">Sort: Highest score</option>
+          <option value="asc">Sort: Lowest score</option>
+          <option value="alpha">Sort: A–Z</option>
+        </select>
+        <button id="refresh" class="btn btn-primary">Refresh</button>
+      </div>
     <div id="grid" class="grid"></div>
   </section>
 
-  <footer>
-    Tip: Bookmark with a query string like <code>?vendors=danversma.gov,topsfield-ma.gov</code> to preload a custom list.
-  </footer>
-
   <script>
-    var DEFAULTS = ["topsfield-ma.gov"]; // server keeps same default
     var grid = document.getElementById('grid');
-    var input = document.getElementById('vendors');
     var sortSel = document.getElementById('sort');
     var btn = document.getElementById('refresh');
-    var reset = document.getElementById('reset');
-
-    function getQueryVendors() {
-      var p = new URLSearchParams(location.search).get('vendors');
-      if (!p) return null;
-      return Array.from(new Set(p.split(',').map(function(s){ return s.trim(); }).filter(Boolean)));
-    }
-
-    function parseVendors() {
-      var raw = (input.value || '').trim();
-      if (!raw) return DEFAULTS.slice();
-      return Array.from(new Set(raw.split(',').map(function(s){ return s.trim(); }).filter(Boolean)));
-    }
 
     function pct(score) { // assume 0..1000 scale
       if (typeof score !== 'number') return 0;
@@ -292,23 +271,16 @@ function renderPage() {
       sorted.forEach(function(r){ grid.appendChild(cardNode(r)); });
     }
 
-    function load() {
-      var list = parseVendors();
-      var qs = encodeURIComponent(list.join(','));
-      fetch('/api/scores?vendors=' + qs)
-        .then(function(res){ return res.json(); })
-        .then(function(data){ render(data.vendors || []); })
-        .catch(function(e){ render([{ hostname: 'dashboard', ok: false, status: 0, error: (e && e.message) ? e.message : String(e) }]); });
-    }
+      function load() {
+        fetch('/api/scores')
+          .then(function(res){ return res.json(); })
+          .then(function(data){ render(data.vendors || []); })
+          .catch(function(e){ render([{ hostname: 'dashboard', ok: false, status: 0, error: (e && e.message) ? e.message : String(e) }]); });
+      }
 
-    btn.onclick = load;
-    reset.onclick = function(){ input.value = DEFAULTS.join(','); load(); };
-
-    // initialize input from query or defaults
-    var initial = getQueryVendors();
-    input.value = (initial && initial.length ? initial : DEFAULTS).join(',');
-    window.addEventListener('DOMContentLoaded', load);
-  </script>
+      btn.onclick = load;
+      window.addEventListener('DOMContentLoaded', load);
+    </script>
 </body>
 </html>`;
   return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });


### PR DESCRIPTION
## Summary
- Drop vendor input and reset controls from dashboard UI
- Always fetch default vendor scores from the worker without query parameters

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68bd94c3d4b88332b8639ac60d481ff8