### PR TITLE
Add UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID to Wrangler vars

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,12 +9,15 @@ enabled = true
 # Optional: turn on Access gating for API routes (set to "1" to require Cf-Access)
 [vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"
 
 [env.staging]
 # Keep same entry file; secrets are environment-specific
 [env.staging.vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"
 
 [env.production]
 [env.production.vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"


### PR DESCRIPTION
### Motivation
- Provide a default UpGuard portfolio identifier so the worker/dashboard can be scoped to `Commonwealth Common Vendors` when the binding is present.

### Description
- Add `UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"` to the `[vars]`, `[env.staging.vars]`, and `[env.production.vars]` sections of `wrangler.toml`.

### Testing
- Verified with `npx wrangler deploy --dry-run` which showed the new var in the worker bindings and ran `git diff --check` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fff476573c8332aa4f0b5f642831de)