### PR TITLE
Rewrite UpGuard dashboard around portfolio risk profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+dist/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "thirdpartyrisk-dashboard",
   "private": true,
   "version": "1.0.0",
-  "description": "Cloudflare Worker: UpGuard score dashboard",
+  "description": "Cloudflare Worker: UpGuard portfolio cyber risk intelligence dashboard",
   "scripts": {
     "dev": "wrangler dev",
     "deploy:staging": "wrangler deploy --env staging",
@@ -10,5 +10,6 @@
   },
   "devDependencies": {
     "wrangler": "^3.81.0"
-  }
+  },
+  "type": "module"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,118 +1,71 @@
-// src/index.js — Cloudflare Worker UpGuard portfolio intelligence dashboard
-// Cloudflare Worker: portfolio-level risk intelligence for the configured UpGuard portfolio.
+// src/index.js — Cloudflare Worker UpGuard portfolio cyber risk intelligence dashboard
+// Portfolio-first risk intelligence for the configured UpGuard Vendor Risk portfolio.
 
 const PORTFOLIO_NAME = "Commonwealth Common Vendors";
 const PORTFOLIO_THRESHOLD = 700;
 const UPGUARD_BASE_URL = "https://cyber-risk.upguard.com/api/public";
+const PORTFOLIO_PAGE_SIZE = 2000;
+
+/**
+ * Stable frontend models emitted by the API routes:
+ * PortfolioOverview, PortfolioRisk, VendorSummary, RiskChangeEvent,
+ * RemediationCampaign, and ReportRequest. The normalizers below isolate
+ * UpGuard response-shape changes from the browser application.
+ */
 
 const REPORT_TYPES = {
-  executive_summary_pdf: { label: "Executive Summary PDF", format: "pdf", scope: "portfolio" },
-  board_summary_pdf: { label: "Board Summary PDF", format: "pdf", scope: "portfolio" },
-  board_summary_pptx: { label: "Board Summary PPTX", format: "pptx", scope: "portfolio" },
-  vendor_detailed_pdf: { label: "Vendor Detailed PDF", format: "pdf", scope: "vendor" },
-  vendor_risk_profile_xlsx: { label: "Vendor Risk Profile XLSX", format: "xlsx", scope: "vendor" },
-  vendor_vulnerabilities_overview_xlsx: { label: "Vendor Vulnerabilities Overview XLSX", format: "xlsx", scope: "vendor" },
-  vendor_domain_list_pdf: { label: "Vendor Domain List PDF", format: "pdf", scope: "vendor" },
+  ExecutiveSummaryPDF: { label: "Executive Summary PDF", format: "pdf", scope: "portfolio" },
+  BoardSummaryPDF: { label: "Board Summary PDF", format: "pdf", scope: "portfolio" },
+  BoardSummaryPPTX: { label: "Board Summary PPTX", format: "pptx", scope: "portfolio" },
+  VendorSummaryPDF: { label: "Vendor Summary PDF", format: "pdf", scope: "vendor" },
+  VendorDetailedPDF: { label: "Vendor Detailed PDF", format: "pdf", scope: "vendor" },
+  VendorRiskProfileXLSX: { label: "Vendor Risk Profile XLSX", format: "xlsx", scope: "vendor" },
+  VendorVulnsOverviewXLSX: { label: "Vendor Vulnerabilities Overview XLSX", format: "xlsx", scope: "vendor" },
 };
 
 const SAMPLE_PORTFOLIO = createSamplePortfolio();
 
 export default {
-  async fetch(req, env, ctx) {
+  async fetch(req, env) {
     const url = new URL(req.url);
     const path = url.pathname;
     const method = req.method;
 
-    if (path === "/" && method === "GET") {
-      return renderPage();
-    }
+    if (path === "/" && method === "GET") return renderPage();
 
     if (path.startsWith("/api/") && (env.REQUIRE_ACCESS || "0") === "1") {
       const token = req.headers.get("Cf-Access-Jwt-Assertion");
       if (!token) return new Response("Unauthorized", { status: 401 });
-      // TODO: verify JWT against Access JWKS for production.
+      // TODO: verify JWT against Access JWKS before enabling this in high-assurance production use.
     }
 
-    if (path === "/api/health") {
-      return json({ ok: true, portfolioName: PORTFOLIO_NAME, ts: Date.now() });
-    }
+    try {
+      if (path === "/api/health" && method === "GET") return json({ ok: true, portfolioName: PORTFOLIO_NAME, ts: Date.now() });
+      if (path === "/api/config" && method === "GET") return json({ portfolioName: PORTFOLIO_NAME, scoreThreshold: PORTFOLIO_THRESHOLD });
 
-    if (path === "/api/config" && method === "GET") {
-      return json({ portfolioName: PORTFOLIO_NAME, scoreThreshold: PORTFOLIO_THRESHOLD });
-    }
+      if (path === "/api/portfolio/risk-profile" && method === "GET") return json(await loadPortfolioRiskProfile(env));
+      if (path === "/api/portfolio/overview" && method === "GET") return json(await loadPortfolioOverview(env));
+      if (path === "/api/portfolio/vendors" && method === "GET") return json(await loadPortfolioVendors(env));
+      if (path === "/api/portfolio/changes" && method === "GET") return json(await loadPortfolioChanges(env, clampInt(url.searchParams.get("days"), 1, 365, 30)));
+      if (path === "/api/portfolio/campaigns" && method === "GET") return json(await loadPortfolioCampaigns(env));
 
-    if (path === "/api/scores" && method === "GET") {
-      const portfolio = await loadPortfolioIntelligence(env);
-      return json({
-        portfolioName: PORTFOLIO_NAME,
-        scopedToPortfolio: true,
-        source: portfolio.source,
-        warning: portfolio.warning,
-        vendors: portfolio.vendors.map((vendor) => ({
-          hostname: vendor.domain,
-          ok: true,
-          score: vendor.score,
-          categoryScores: vendor.categoryScores || null,
-          updatedAt: vendor.lastUpdated,
-        })),
-      });
-    }
+      if (path === "/api/vendor/detail" && method === "GET") {
+        const hostname = url.searchParams.get("hostname") || url.searchParams.get("domain") || "";
+        if (!hostname) return json({ error: "missing_hostname", message: "Provide hostname or domain." }, 400);
+        return json(await loadVendorDetail(env, hostname));
+      }
 
-    if (path === "/api/portfolio/risk-profile" && method === "GET") {
-      const riskProfile = await loadPortfolioRiskProfile(env);
-      return json(riskProfile);
-    }
+      if (path === "/api/reports/request" && method === "POST") return handleReportRequest(req, env);
+      if (path === "/api/reports/status" && method === "GET") return json(reportStatus(url.searchParams.get("id") || ""));
+      if (path === "/api/reports/download" && method === "GET") return reportDownload(url.searchParams.get("id") || "portfolio-report");
 
-    if (path === "/api/portfolio/overview" && method === "GET") {
-      const riskProfile = await loadPortfolioRiskProfile(env);
-      const portfolio = await loadPortfolioIntelligence(env);
-      return json(normalizePortfolioOverview(portfolio, riskProfile));
-    }
-
-    if (path === "/api/portfolio/vendors" && method === "GET") {
-      const portfolio = await loadPortfolioIntelligence(env);
-      return json({ portfolioName: PORTFOLIO_NAME, source: portfolio.source, warning: portfolio.warning, vendors: normalizeVendorSummaries(portfolio) });
-    }
-
-    if (path === "/api/portfolio/risks" && method === "GET") {
-      const riskProfile = await loadPortfolioRiskProfile(env);
-      return json({
-        portfolioName: riskProfile.portfolioName,
-        portfolioId: riskProfile.portfolioId,
-        source: riskProfile.source,
-        warning: riskProfile.warning,
-        risks: riskProfile.risks,
-      });
-    }
-
-    if (path === "/api/portfolio/changes" && method === "GET") {
-      const days = clampInt(url.searchParams.get("days"), 1, 365, 30);
-      const portfolio = await loadPortfolioIntelligence(env);
-      return json({ portfolioName: PORTFOLIO_NAME, source: portfolio.source, warning: portfolio.warning, days, changes: normalizeRiskChanges(portfolio, days) });
-    }
-
-    if (path === "/api/portfolio/campaigns" && method === "GET") {
-      const riskProfile = await loadPortfolioRiskProfile(env);
-      return json({ portfolioName: PORTFOLIO_NAME, source: riskProfile.source, warning: riskProfile.warning, campaigns: normalizeRemediationCampaigns({ risks: riskProfile.risks, vendors: [] }) });
-    }
-
-    if (path === "/api/reports/request" && method === "POST") {
-      return handleReportRequest(req, env);
-    }
-
-    if (path === "/api/reports/status" && method === "GET") {
-      const id = url.searchParams.get("id") || "";
-      return json({ id, portfolioName: PORTFOLIO_NAME, status: id ? "ready" : "missing_id", message: id ? "Placeholder report workflow is ready for UpGuard report endpoint wiring." : "Provide a report id." });
-    }
-
-    if (path === "/api/reports/download" && method === "GET") {
-      const id = url.searchParams.get("id") || "portfolio-report";
-      return new Response("Report placeholder for " + PORTFOLIO_NAME + " (" + id + "). TODO: connect to confirmed UpGuard report download endpoint.", {
-        headers: {
-          "Content-Type": "text/plain; charset=utf-8",
-          "Content-Disposition": "attachment; filename=\"" + safeFileName(PORTFOLIO_NAME) + "-" + safeFileName(id) + ".txt\"",
-        },
-      });
+      // Backwards-compatible score-card route retained for existing integrations; sourced from portfolio intelligence.
+      if (path === "/api/scores" && method === "GET") {
+        const vendors = await loadPortfolioVendors(env);
+        return json({ portfolioName: PORTFOLIO_NAME, source: vendors.source, warning: vendors.warning, vendors: vendors.vendors.map((v) => ({ hostname: v.domain, ok: true, score: v.score, categoryScores: v.categoryScores, updatedAt: v.lastUpdated })) });
+      }
+    } catch (e) {
+      return json({ error: "worker_error", message: e && e.message ? e.message : String(e), portfolioName: PORTFOLIO_NAME }, 500);
     }
 
     return new Response("Not found", { status: 404 });
@@ -120,40 +73,41 @@ export default {
 };
 
 function getConfiguredPortfolioId(env) {
-  const PORTFOLIO_ID = ((env || {}).UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID || "").trim();
-  return PORTFOLIO_ID;
+  return String((env || {}).UPGUARD_PORTFOLIO_ID || "").trim();
+}
+
+function hasUpGuardConfig(env) {
+  return Boolean(String((env || {}).UPGUARD_API_KEY || "").trim() && getConfiguredPortfolioId(env));
 }
 
 async function loadPortfolioRiskProfile(env) {
-  const apiKey = (env.UPGUARD_API_KEY || "").trim();
+  const apiKey = String((env || {}).UPGUARD_API_KEY || "").trim();
   const portfolioId = getConfiguredPortfolioId(env);
 
-  if (!apiKey) {
-    return withSampleRiskProfileWarning(null, "missing_api_key", "UPGUARD_API_KEY is not configured; showing sample risk profile data scoped to " + PORTFOLIO_NAME + ".");
-  }
-  if (!portfolioId) {
-    return withSampleRiskProfileWarning(null, "missing_portfolio_id", "UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID is not configured; showing sample risk profile data scoped to " + PORTFOLIO_NAME + ".");
-  }
+  if (!apiKey) return withSampleRiskProfileWarning(null, "missing_api_key", "UPGUARD_API_KEY is not configured; showing sample portfolio risk profile data.");
+  if (!portfolioId) return withSampleRiskProfileWarning(null, "missing_portfolio_id", "UPGUARD_PORTFOLIO_ID is not configured; showing sample portfolio risk profile data.");
 
   try {
-    const pages = await fetchUpGuardPortfolioRiskProfilePages(apiKey, portfolioId);
-    return normalizePortfolioRiskProfilePages(pages, portfolioId, "upguard", null);
+    const pages = await fetchPortfolioRiskProfilePages(env, portfolioId);
+    const normalized = normalizePortfolioRiskProfilePages(pages, portfolioId, "upguard", null);
+    // TODO(D1): persist normalized risk profile snapshots here for longitudinal portfolio trends.
+    return normalized;
   } catch (e) {
-    return withSampleRiskProfileWarning(portfolioId, "upguard_risk_profile_unavailable", (e && e.message ? e.message : String(e)) + "; showing sample risk profile data.");
+    return withSampleRiskProfileWarning(portfolioId, "upguard_risk_profile_unavailable", (e && e.message ? e.message : String(e)) + "; showing sample portfolio risk profile data.");
   }
 }
 
-async function fetchUpGuardPortfolioRiskProfilePages(apiKey, portfolioId) {
+async function fetchPortfolioRiskProfilePages(env, portfolioId) {
   const pages = [];
   let pageToken = "";
   const seenTokens = new Set();
 
   do {
-    const params = new URLSearchParams({ portfolios: portfolioId, page_size: "2000" });
+    const params = new URLSearchParams({ portfolios: portfolioId, page_size: String(PORTFOLIO_PAGE_SIZE) });
     if (pageToken) params.set("page_token", pageToken);
-    const data = await fetchUpGuardJson(apiKey, "/risks/vendors/all?" + params.toString());
-    pages.push(data);
-    pageToken = String(data.next_page_token || data.nextPageToken || data.next || "");
+    const page = await fetchUpGuardJson(env, "/risks/vendors/all?" + params.toString());
+    pages.push(page);
+    pageToken = String(page.next_page_token || page.nextPageToken || page.pagination?.next_page_token || "");
     if (pageToken && seenTokens.has(pageToken)) throw new Error("UpGuard risk-profile pagination returned a repeated next_page_token.");
     if (pageToken) seenTokens.add(pageToken);
   } while (pageToken);
@@ -161,149 +115,114 @@ async function fetchUpGuardPortfolioRiskProfilePages(apiKey, portfolioId) {
   return pages;
 }
 
-function normalizePortfolioRiskProfilePages(pages, portfolioId, source, warning) {
-  const allRisks = [];
-  let totalVendors = null;
-
-  for (const page of pages) {
-    const pageTotal = numberOrNull(page.total_vendors ?? page.totalVendors ?? page.total_vendor_count ?? page.total_vendor_count_matching_filter ?? page.total ?? page.count);
-    if (pageTotal !== null) totalVendors = Math.max(totalVendors || 0, pageTotal);
-    allRisks.push(...extractRiskProfileRisks(page));
-  }
-
-  const risks = mergePortfolioRiskProfileRisks(allRisks);
-  const severityCounts = countBy(risks, "severity", true);
-  const categoryCounts = countBy(risks, "category", true);
-  const topRisks = risks.slice(0, 10);
-
-  return {
-    portfolioName: PORTFOLIO_NAME,
-    portfolioId,
-    source,
-    warning,
-    totalVendors: totalVendors ?? SAMPLE_PORTFOLIO.vendors.length,
-    risks,
-    severityCounts,
-    categoryCounts,
-    topRisks,
-    generatedAt: new Date().toISOString(),
-  };
+async function loadPortfolioOverview(env) {
+  const riskProfile = await loadPortfolioRiskProfile(env);
+  const vendorModel = await buildVendorSummariesFromRiskProfile(env, riskProfile);
+  const changesModel = await loadPortfolioChanges(env, 30);
+  const campaigns = normalizeRemediationCampaigns(riskProfile.risks);
+  return normalizePortfolioOverview(riskProfile, vendorModel.vendors, changesModel.changes, campaigns);
 }
 
-function extractRiskProfileRisks(page) {
-  const direct = asArray(page.risks || page.findings || page.results || page.data, ["risks", "findings", "results", "data"]);
-  if (direct.length) return direct;
-
-  const nested = [];
-  for (const value of Object.values(page || {})) {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      nested.push(...asArray(value.risks || value.findings || value.results || value.data, ["risks", "findings", "results", "data"]));
-    }
-  }
-  return nested;
+async function loadPortfolioVendors(env) {
+  const riskProfile = await loadPortfolioRiskProfile(env);
+  const vendorModel = await buildVendorSummariesFromRiskProfile(env, riskProfile);
+  return { portfolioName: PORTFOLIO_NAME, portfolioId: riskProfile.portfolioId, source: vendorModel.source, warning: riskProfile.warning || vendorModel.warning, vendors: vendorModel.vendors, generatedAt: new Date().toISOString() };
 }
 
-function mergePortfolioRiskProfileRisks(rawRisks) {
-  const grouped = new Map();
-
-  for (const rawRisk of rawRisks) {
-    const risk = normalizeRiskProfileRecord(rawRisk);
-    const key = [risk.name, risk.severity, risk.category, risk.type, risk.subtype].map((value) => String(value || "").toLowerCase()).join("|");
-    if (!grouped.has(key)) {
-      grouped.set(key, { ...risk, vendorsImpacted: 0, affectedHostnames: new Set(risk.affectedHostnames || []) });
-    }
-    const item = grouped.get(key);
-    item.vendorsImpacted += Math.max(risk.vendorsImpacted, 0);
-    for (const hostname of risk.affectedHostnames || []) item.affectedHostnames.add(hostname);
-    if (risk.firstDetected && (!item.firstDetected || new Date(risk.firstDetected) < new Date(item.firstDetected))) item.firstDetected = risk.firstDetected;
-    if (!item.recommendation && risk.recommendation) item.recommendation = risk.recommendation;
-  }
-
-  return Array.from(grouped.values()).map((risk) => ({
-    ...risk,
-    vendorsImpacted: risk.vendorsImpacted || 1,
-    affectedHostnames: Array.from(risk.affectedHostnames).slice(0, 12),
-  })).sort(compareRiskPriority);
-}
-
-function normalizeRiskProfileRecord(risk) {
-  const normalized = normalizeRiskRecord(risk);
-  return {
-    id: normalized.id,
-    name: normalized.name,
-    severity: normalized.severity,
-    category: normalized.category,
-    type: normalized.type || "—",
-    subtype: normalized.subtype || "—",
-    vendorsImpacted: numberOrZero(risk.vendors_affected ?? risk.affected_vendors ?? risk.affected_vendor_count ?? risk.vendor_count ?? risk.vendorsImpacted ?? normalized.vendorsImpacted),
-    affectedHostnames: asArray(risk.hostnames || risk.hosts || risk.domains || risk.assets || risk.affectedHostnames, []),
-    firstDetected: normalized.firstDetected,
-    recommendation: normalized.recommendation,
-    status: normalized.status,
-  };
-}
-
-function countBy(items, field, weightByVendors) {
-  return items.reduce((counts, item) => {
-    const key = item[field] || "Uncategorized";
-    counts[key] = (counts[key] || 0) + (weightByVendors ? Math.max(numberOrZero(item.vendorsImpacted), 1) : 1);
-    return counts;
-  }, {});
-}
-
-function withSampleRiskProfileWarning(portfolioId, code, message) {
-  return normalizePortfolioRiskProfilePages([{ total_vendors: SAMPLE_PORTFOLIO.vendors.length, risks: normalizePortfolioRisks(SAMPLE_PORTFOLIO) }], portfolioId, "sample", { code, message });
-}
-
-async function loadPortfolioIntelligence(env) {
-  const apiKey = (env.UPGUARD_API_KEY || "").trim();
-  if (!apiKey) {
-    return withSampleWarning("missing_api_key", "UPGUARD_API_KEY is not configured; showing sample data scoped to " + PORTFOLIO_NAME + ".");
+async function loadPortfolioChanges(env, days) {
+  if (!hasUpGuardConfig(env)) {
+    return { portfolioName: PORTFOLIO_NAME, source: "sample", warning: missingConfigWarning(env), days, changes: sampleChanges(days), generatedAt: new Date().toISOString() };
   }
 
   try {
-    const portfolioId = getConfiguredPortfolioId(env);
-    if (!portfolioId) {
-      return withSampleWarning("missing_portfolio_id", "UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID is not configured; showing sample data scoped to " + PORTFOLIO_NAME + ".");
-    }
-
-    const [vendorsRaw, risksRaw, changesRaw] = await Promise.all([
-      fetchUpGuardJson(apiKey, "/portfolios/" + encodeURIComponent(portfolioId) + "/vendors"),
-      fetchUpGuardJson(apiKey, "/portfolios/" + encodeURIComponent(portfolioId) + "/risks"),
-      fetchUpGuardJson(apiKey, "/portfolios/" + encodeURIComponent(portfolioId) + "/changes?days=30"),
-    ]);
-
-    return normalizeUpGuardPortfolioPayload({ id: portfolioId, name: PORTFOLIO_NAME }, vendorsRaw, risksRaw, changesRaw);
+    const params = new URLSearchParams({ portfolios: getConfiguredPortfolioId(env), days: String(days) });
+    const data = await fetchUpGuardJson(env, "/risk/vendors/diff?" + params.toString());
+    const changes = extractItems(data, ["changes", "events", "results", "data", "diffs"]).map(normalizeChangeRecord).sort(sortNewestChangeFirst);
+    // TODO(D1): persist diff events and derived snapshots for trend analysis and resolved-risk reporting.
+    return { portfolioName: PORTFOLIO_NAME, portfolioId: getConfiguredPortfolioId(env), source: "upguard", warning: null, days, changes, generatedAt: new Date().toISOString() };
   } catch (e) {
-    return withSampleWarning("upguard_unavailable", (e && e.message ? e.message : String(e)) + "; showing sample portfolio intelligence.");
+    return { portfolioName: PORTFOLIO_NAME, portfolioId: getConfiguredPortfolioId(env), source: "sample", warning: { code: "upguard_diff_unavailable", message: (e && e.message ? e.message : String(e)) + "; showing sample change events." }, days, changes: sampleChanges(days), generatedAt: new Date().toISOString() };
   }
 }
 
-async function findUpGuardPortfolio(apiKey, name) {
-  // TODO: Confirm the exact UpGuard portfolio listing/filter endpoint and response shape.
-  const candidates = [
-    "/portfolios?name=" + encodeURIComponent(name),
-    "/portfolio?name=" + encodeURIComponent(name),
-    "/portfolios",
-  ];
+async function loadPortfolioCampaigns(env) {
+  const riskProfile = await loadPortfolioRiskProfile(env);
+  return { portfolioName: PORTFOLIO_NAME, portfolioId: riskProfile.portfolioId, source: riskProfile.source, warning: riskProfile.warning, campaigns: normalizeRemediationCampaigns(riskProfile.risks), generatedAt: new Date().toISOString() };
+}
 
-  for (const endpoint of candidates) {
-    try {
-      const data = await fetchUpGuardJson(apiKey, endpoint);
-      const list = Array.isArray(data) ? data : (data.portfolios || data.data || data.results || []);
-      const match = list.find((p) => String(p.name || p.title || "").toLowerCase() === name.toLowerCase());
-      if (match) return match;
-      if (!Array.isArray(data) && String(data.name || data.title || "").toLowerCase() === name.toLowerCase()) return data;
-    } catch (e) {
-      // Try the next documented-or-likely endpoint before falling back.
+async function loadVendorDetail(env, hostname) {
+  const fallback = vendorDetailFromSample(hostname);
+  if (!hasUpGuardConfig(env)) return { ...fallback, source: "sample", warning: missingConfigWarning(env) };
+
+  try {
+    const data = await fetchUpGuardJson(env, "/vendor?hostname=" + encodeURIComponent(hostname));
+    return normalizeVendorDetail(data, hostname, "upguard", null);
+  } catch (e) {
+    return { ...fallback, source: "sample", warning: { code: "upguard_vendor_unavailable", message: (e && e.message ? e.message : String(e)) + "; showing sample or portfolio-derived vendor detail." } };
+  }
+}
+
+async function buildVendorSummariesFromRiskProfile(env, riskProfile) {
+  const domains = Array.from(new Set((riskProfile.risks || []).flatMap((risk) => risk.affectedHostnames || []).filter(Boolean))).sort();
+  const source = riskProfile.source;
+  const warning = riskProfile.warning;
+
+  if (!domains.length && source === "sample") return { source, warning, vendors: normalizeSampleVendorSummaries() };
+
+  const riskByDomain = new Map();
+  for (const domain of domains) riskByDomain.set(domain, []);
+  for (const risk of riskProfile.risks || []) {
+    for (const domain of risk.affectedHostnames || []) {
+      if (!riskByDomain.has(domain)) riskByDomain.set(domain, []);
+      riskByDomain.get(domain).push(risk);
     }
   }
-  return null;
+
+  const shouldFetchScores = hasUpGuardConfig(env) && source === "upguard";
+  const scoreDetails = new Map();
+  if (shouldFetchScores) {
+    const limitedDomains = domains.slice(0, 120);
+    const results = await Promise.allSettled(limitedDomains.map((domain) => fetchUpGuardJson(env, "/vendor?hostname=" + encodeURIComponent(domain))));
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") scoreDetails.set(limitedDomains[index], normalizeVendorDetail(result.value, limitedDomains[index], "upguard", null));
+    });
+  }
+
+  const vendors = domains.map((domain) => {
+    const risks = riskByDomain.get(domain) || [];
+    const detail = scoreDetails.get(domain);
+    const criticalRiskCount = risks.filter((risk) => risk.severity === "critical").length;
+    const highRiskCount = risks.filter((risk) => risk.severity === "high").length;
+    const score = detail?.score ?? null;
+    const trend30d = detail?.trend30d ?? 0;
+    const summary = {
+      id: domain,
+      name: detail?.name || domain,
+      domain,
+      score,
+      trend30d,
+      criticalRiskCount,
+      highRiskCount,
+      totalOpenRisks: risks.length,
+      lastUpdated: detail?.lastUpdated || riskProfile.generatedAt,
+      priority: "Monitor",
+      categoryScores: detail?.categoryScores || null,
+      activeFindings: risks.slice(0, 8),
+      recentChanges: [],
+    };
+    summary.priority = priorityForVendor(summary);
+    return summary;
+  }).sort(compareVendorPriority);
+
+  return { source, warning, vendors };
 }
 
-async function fetchUpGuardJson(apiKey, endpoint) {
+async function fetchUpGuardJson(env, endpoint) {
   const response = await fetch(UPGUARD_BASE_URL + endpoint, {
-    headers: { Authorization: apiKey, Accept: "application/json" },
+    headers: {
+      "Authorization": env.UPGUARD_API_KEY,
+      "Accept": "application/json",
+    },
   });
   if (!response.ok) {
     const body = await response.text();
@@ -312,274 +231,274 @@ async function fetchUpGuardJson(apiKey, endpoint) {
   return response.json();
 }
 
-function normalizeUpGuardPortfolioPayload(portfolio, vendorsRaw, risksRaw, changesRaw) {
-  const rawVendors = asArray(vendorsRaw, ["vendors", "data", "results"]);
-  const rawRisks = asArray(risksRaw, ["risks", "findings", "data", "results"]);
-  const rawChanges = asArray(changesRaw, ["changes", "events", "data", "results"]);
+function normalizePortfolioRiskProfilePages(pages, portfolioId, source, warning) {
+  const rawRisks = [];
+  let totalVendors = null;
+  let totalRisks = null;
 
-  const vendors = rawVendors.map((vendor) => ({
-    id: String(vendor.id || vendor.uuid || vendor.hostname || vendor.primary_hostname || vendor.domain || vendor.name || "vendor"),
-    name: vendor.name || vendor.company_name || vendor.primary_hostname || vendor.hostname || vendor.domain || "Unknown vendor",
-    domain: vendor.primary_hostname || vendor.hostname || vendor.domain || vendor.website || vendor.name || "unknown-domain",
-    score: numberOrNull(vendor.score) ?? numberOrNull(vendor.overallScore) ?? numberOrNull(vendor.current_score),
-    trend30d: numberOrZero(vendor.trend_30d ?? vendor.score_change_30d ?? vendor.thirty_day_trend),
-    lastUpdated: vendor.updated_at || vendor.last_updated || vendor.last_scanned_at || null,
-    categoryScores: vendor.categoryScores || vendor.category_scores || null,
-    risks: [],
-  }));
-
-  const vendorByKey = new Map();
-  vendors.forEach((vendor) => {
-    vendorByKey.set(vendor.id, vendor);
-    vendorByKey.set(String(vendor.domain).toLowerCase(), vendor);
-    vendorByKey.set(String(vendor.name).toLowerCase(), vendor);
-  });
-
-  for (const risk of rawRisks) {
-    const vendorKey = String(risk.vendor_id || risk.vendor_uuid || risk.vendor || risk.hostname || risk.domain || risk.vendor_name || "").toLowerCase();
-    const normalizedRisk = normalizeRiskRecord(risk);
-    const vendor = vendorByKey.get(vendorKey);
-    if (vendor) vendor.risks.push(normalizedRisk);
+  for (const page of pages || []) {
+    const pageTotalVendors = numberOrNull(page.total_vendors ?? page.totalVendors ?? page.total_vendor_count ?? page.total_vendor_count_matching_filter ?? page.total_vendors_matching_filter ?? page.vendor_count);
+    if (pageTotalVendors !== null) totalVendors = Math.max(totalVendors || 0, pageTotalVendors);
+    const pageTotalRisks = numberOrNull(page.total_risks ?? page.totalRisks ?? page.total_count ?? page.count);
+    if (pageTotalRisks !== null) totalRisks = Math.max(totalRisks || 0, pageTotalRisks);
+    rawRisks.push(...extractItems(page, ["risks", "findings", "grouped_risks", "common_risks", "results", "data"]));
   }
+
+  const risks = mergePortfolioRisks(rawRisks);
+  const totalAffectedVendors = risks.reduce((sum, risk) => sum + Math.max(risk.vendorsImpacted, 1), 0);
 
   return {
     portfolioName: PORTFOLIO_NAME,
-    portfolioId: portfolio.id || portfolio.uuid || portfolio.slug || null,
-    source: "upguard",
-    warning: null,
-    vendors,
-    risks: rawRisks.map(normalizeRiskRecord),
-    changes: rawChanges.map(normalizeChangeRecord),
+    portfolioId,
+    source,
+    warning,
+    totalVendors: totalVendors ?? deriveVendorCount(risks),
+    totalRisks: totalRisks ?? risks.length,
+    totalAffectedVendors,
+    severityCounts: countBy(risks, "severity", true),
+    categoryCounts: countBy(risks, "category", true),
+    topRisks: risks.slice(0, 5),
+    mostSevereIssue: risks[0] || null,
+    risks,
+    generatedAt: new Date().toISOString(),
   };
 }
 
-function normalizeRiskRecord(risk) {
+function extractItems(value, preferredKeys) {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== "object") return [];
+  for (const key of preferredKeys) {
+    if (Array.isArray(value[key])) return value[key];
+  }
+  for (const key of preferredKeys) {
+    if (value[key] && typeof value[key] === "object") {
+      const nested = extractItems(value[key], preferredKeys);
+      if (nested.length) return nested;
+    }
+  }
+  return [];
+}
+
+function mergePortfolioRisks(rawRisks) {
+  const grouped = new Map();
+  for (const raw of rawRisks || []) {
+    const risk = normalizePortfolioRisk(raw);
+    const key = [risk.name, risk.severity, risk.category, risk.type, risk.subtype].map((v) => String(v || "").toLowerCase()).join("|");
+    if (!grouped.has(key)) grouped.set(key, { ...risk, vendorsImpacted: 0, affectedHostnames: new Set(), rawVendorCountSeen: false });
+    const item = grouped.get(key);
+    if (risk.vendorsImpacted > 0) {
+      item.vendorsImpacted += risk.vendorsImpacted;
+      item.rawVendorCountSeen = true;
+    }
+    for (const host of risk.affectedHostnames || []) item.affectedHostnames.add(host);
+    if (risk.firstDetected && (!item.firstDetected || new Date(risk.firstDetected) < new Date(item.firstDetected))) item.firstDetected = risk.firstDetected;
+    if (!item.recommendation && risk.recommendation) item.recommendation = risk.recommendation;
+  }
+
+  return Array.from(grouped.values()).map((risk) => {
+    const hostnames = Array.from(risk.affectedHostnames).sort();
+    return {
+      id: risk.id,
+      name: risk.name,
+      severity: risk.severity,
+      category: risk.category,
+      type: risk.type || "—",
+      subtype: risk.subtype || "—",
+      vendorsImpacted: risk.rawVendorCountSeen ? Math.max(risk.vendorsImpacted, hostnames.length, 1) : Math.max(hostnames.length, 1),
+      affectedHostnames: hostnames,
+      firstDetected: risk.firstDetected,
+      recommendation: risk.recommendation || recommendationForRisk(risk.name, risk.category),
+      status: risk.status || "open",
+    };
+  }).sort(compareRiskPriority);
+}
+
+function normalizePortfolioRisk(raw) {
+  const name = raw.name || raw.title || raw.finding || raw.finding_name || raw.risk_name || raw.risk || "Unnamed finding";
+  const hostCandidates = [raw.hostnames, raw.hosts, raw.domains, raw.domain_names, raw.assets, raw.affected_hostnames, raw.affected_domains, raw.vendors, raw.vendor_domains];
+  const affectedHostnames = hostCandidates.flatMap(hostListFromValue).filter(Boolean);
   return {
-    id: String(risk.id || risk.uuid || risk.name || risk.title || "risk"),
-    name: risk.name || risk.title || risk.finding || risk.risk_name || "Unnamed finding",
-    severity: normalizeSeverity(risk.severity || risk.risk_severity || risk.priority),
-    category: risk.category || risk.risk_category || risk.group || "Uncategorized",
-    type: risk.type || risk.risk_type || risk.subtype || risk.finding_type || "",
-    subtype: risk.subtype || risk.risk_subtype || "",
-    vendorsImpacted: numberOrZero(risk.vendors_impacted || risk.vendor_count),
-    hostnames: asArray(risk.hostnames || risk.hosts || risk.domains || risk.assets, []),
-    firstDetected: risk.first_detected || risk.first_seen || risk.created_at || null,
-    recommendation: risk.recommendation || risk.remediation || recommendationForRisk(risk.name || risk.title || "", risk.category || ""),
-    vendorName: risk.vendor_name || risk.vendor || null,
-    vendorDomain: risk.domain || risk.hostname || null,
-    status: risk.status || "open",
+    id: String(raw.id || raw.uuid || raw.risk_id || name),
+    name,
+    severity: normalizeSeverity(raw.severity || raw.risk_severity || raw.priority || raw.score_severity),
+    category: raw.category || raw.risk_category || raw.group || raw.family || "Uncategorized",
+    type: raw.type || raw.risk_type || raw.finding_type || "—",
+    subtype: raw.subtype || raw.risk_subtype || raw.finding_subtype || "—",
+    vendorsImpacted: numberOrZero(raw.vendors_affected ?? raw.affected_vendors ?? raw.affected_vendor_count ?? raw.vendor_count ?? raw.vendorsImpacted ?? raw.count),
+    affectedHostnames,
+    firstDetected: raw.first_detected || raw.first_seen || raw.first_observed_at || raw.created_at || null,
+    recommendation: raw.recommendation || raw.remediation || raw.remediation_recommendation || recommendationForRisk(name, raw.category || raw.risk_category || ""),
+    status: raw.status || "open",
+  };
+}
+
+function normalizePortfolioOverview(riskProfile, vendors, changes, campaigns) {
+  const scoreValues = vendors.map((v) => v.score).filter((score) => typeof score === "number");
+  const averageScore = scoreValues.length ? Math.round(scoreValues.reduce((sum, score) => sum + score, 0) / scoreValues.length) : null;
+  const criticalRiskCount = (riskProfile.risks || []).filter((risk) => risk.severity === "critical").reduce((sum, risk) => sum + Math.max(risk.vendorsImpacted, 1), 0);
+  const highRiskCount = (riskProfile.risks || []).filter((risk) => risk.severity === "high").reduce((sum, risk) => sum + Math.max(risk.vendorsImpacted, 1), 0);
+  const topFinding = riskProfile.topRisks?.[0] || riskProfile.risks?.[0] || null;
+  const mostSevereIssue = riskProfile.mostSevereIssue || topFinding;
+  const topCampaign = campaigns[0] || null;
+  const vendorCount = riskProfile.totalVendors || vendors.length;
+
+  return {
+    portfolioName: PORTFOLIO_NAME,
+    portfolioId: riskProfile.portfolioId,
+    source: riskProfile.source,
+    warning: riskProfile.warning,
+    totalVendors: vendorCount,
+    vendorCount,
+    averageScore,
+    criticalRiskCount,
+    highRiskCount,
+    vendorsBelowThreshold: vendors.filter((v) => typeof v.score === "number" && v.score < PORTFOLIO_THRESHOLD).length,
+    topRisks: riskProfile.topRisks || [],
+    topFindingName: topFinding ? topFinding.name : "No common findings detected",
+    topFindingAffectedVendorCount: topFinding ? topFinding.vendorsImpacted : 0,
+    mostSevereIssue,
+    totalAffectedVendors: riskProfile.totalAffectedVendors || 0,
+    newlyIntroduced30d: changes.filter((c) => c.changeType === "New Risk" || c.changeType === "Severity Increased").length,
+    remediated30d: changes.filter((c) => c.changeType === "Resolved Risk" || c.changeType === "Severity Reduced").length,
+    topCampaignRecommendation: topCampaign ? topCampaign.recommendedAction : "Continue monitoring portfolio changes and validate remediation ownership.",
+    generatedAt: new Date().toISOString(),
+    executiveSummary: generateExecutiveSummary(vendorCount, averageScore, criticalRiskCount, highRiskCount, topFinding),
+  };
+}
+
+function normalizeVendorDetail(data, hostname, source, warning) {
+  const vendor = data.vendor || data.data || data;
+  return {
+    id: String(vendor.id || vendor.uuid || hostname),
+    name: vendor.name || vendor.company_name || vendor.hostname || hostname,
+    domain: vendor.primary_hostname || vendor.hostname || vendor.domain || hostname,
+    score: numberOrNull(vendor.score ?? vendor.overall_score ?? vendor.current_score ?? vendor.security_score),
+    trend30d: numberOrZero(vendor.trend_30d ?? vendor.score_change_30d ?? vendor.thirty_day_trend ?? vendor.scoreTrend),
+    lastUpdated: vendor.updated_at || vendor.last_updated || vendor.last_scanned_at || null,
+    categoryScores: vendor.category_scores || vendor.categoryScores || vendor.categories || null,
+    activeFindings: extractItems(vendor, ["risks", "findings", "active_findings", "open_risks"]).map(normalizePortfolioRisk),
+    recentChanges: extractItems(vendor, ["changes", "events", "recent_changes"]).map(normalizeChangeRecord),
+    riskHistory: vendor.risk_history || vendor.score_history || vendor.history || null,
+    source,
+    warning,
   };
 }
 
 function normalizeChangeRecord(change) {
   return {
-    id: String(change.id || change.uuid || change.detected_at || change.date || "change"),
-    dateDetected: change.detected_at || change.date || change.created_at || new Date().toISOString(),
-    vendor: change.vendor_name || change.vendor || change.hostname || change.domain || "Unknown vendor",
-    changeType: normalizeChangeType(change.change_type || change.type || change.status),
+    id: String(change.id || change.uuid || change.detected_at || change.date || change.name || "change"),
+    date: change.detected_at || change.date || change.created_at || change.updated_at || new Date().toISOString(),
+    dateDetected: change.detected_at || change.date || change.created_at || change.updated_at || new Date().toISOString(),
+    vendor: change.vendor_name || change.vendor || change.hostname || change.domain || change.company_name || "Unknown vendor",
+    changeType: normalizeChangeType(change.change_type || change.type || change.status || change.diff_type),
+    finding: change.finding_name || change.risk_name || change.name || change.title || "Unnamed finding",
     findingName: change.finding_name || change.risk_name || change.name || change.title || "Unnamed finding",
-    severity: normalizeSeverity(change.severity || change.risk_severity),
-    affectedAsset: change.hostname || change.domain || change.asset || "—",
+    severity: normalizeSeverity(change.severity || change.risk_severity || change.priority),
+    affectedHostname: change.hostname || change.domain || change.asset || change.affected_hostname || "—",
+    affectedAsset: change.hostname || change.domain || change.asset || change.affected_hostname || "—",
   };
 }
 
-function normalizePortfolioOverview(portfolio, riskProfile) {
-  const vendors = normalizeVendorSummaries(portfolio);
-  const risks = riskProfile && Array.isArray(riskProfile.risks) ? riskProfile.risks : normalizePortfolioRisks(portfolio);
-  const changes = normalizeRiskChanges(portfolio, 30);
-  const campaigns = normalizeRemediationCampaigns({ risks, vendors: [] });
-  const scoreValues = vendors.map((vendor) => vendor.score).filter((score) => typeof score === "number");
-  const averageScore = scoreValues.length ? Math.round(scoreValues.reduce((sum, score) => sum + score, 0) / scoreValues.length) : null;
-  const criticalRiskCount = risks.filter((risk) => risk.severity === "critical").reduce((sum, risk) => sum + Math.max(numberOrZero(risk.vendorsImpacted), 1), 0);
-  const highRiskCount = risks.filter((risk) => risk.severity === "high").reduce((sum, risk) => sum + Math.max(numberOrZero(risk.vendorsImpacted), 1), 0);
-  const topFinding = (riskProfile && riskProfile.topRisks && riskProfile.topRisks[0]) || risks[0] || null;
-  const topCampaign = campaigns[0] || null;
-  const newlyIntroduced30d = changes.filter((change) => change.changeType === "new risk" || change.changeType === "worsened").length;
-  const remediated30d = changes.filter((change) => change.changeType === "resolved risk" || change.changeType === "improved").length;
-  const vendorCount = riskProfile && typeof riskProfile.totalVendors === "number" ? riskProfile.totalVendors : vendors.length;
-
-  return {
-    portfolioName: PORTFOLIO_NAME,
-    portfolioId: riskProfile ? riskProfile.portfolioId : portfolio.portfolioId,
-    source: riskProfile ? riskProfile.source : portfolio.source,
-    warning: (riskProfile && riskProfile.warning) || portfolio.warning,
-    averageScore,
-    vendorCount,
-    totalVendors: vendorCount,
-    severityCounts: riskProfile ? riskProfile.severityCounts : countBy(risks, "severity", true),
-    categoryCounts: riskProfile ? riskProfile.categoryCounts : countBy(risks, "category", true),
-    criticalRiskCount,
-    highRiskCount,
-    vendorsBelowThreshold: vendors.filter((vendor) => typeof vendor.score === "number" && vendor.score < PORTFOLIO_THRESHOLD).length,
-    newlyIntroduced30d,
-    remediated30d,
-    topFindingName: topFinding ? topFinding.name : "No common findings detected",
-    topFindingAffectedVendorCount: topFinding ? topFinding.vendorsImpacted : 0,
-    topCampaignRecommendation: topCampaign ? topCampaign.nextAction : "Continue monitoring portfolio changes and validate report coverage.",
-    executiveSummary: generateExecutiveSummary(vendorCount, averageScore, criticalRiskCount, highRiskCount, topFinding, topCampaign),
-  };
-}
-
-function normalizeVendorSummaries(portfolio) {
-  return portfolio.vendors.map((vendor) => {
-    const risks = vendor.risks && vendor.risks.length ? vendor.risks : portfolio.risks.filter((risk) => (risk.vendorName && risk.vendorName === vendor.name) || (risk.vendorDomain && risk.vendorDomain === vendor.domain));
-    const criticalRiskCount = risks.filter((risk) => risk.severity === "critical").length;
-    const highRiskCount = risks.filter((risk) => risk.severity === "high").length;
-    const totalOpenRisks = risks.filter((risk) => risk.status !== "resolved").length;
-    const priority = priorityForVendor({ score: vendor.score, trend30d: vendor.trend30d, criticalRiskCount, highRiskCount, totalOpenRisks });
-    return {
-      id: vendor.id,
-      name: vendor.name,
-      domain: vendor.domain,
-      score: vendor.score,
-      trend30d: vendor.trend30d,
-      criticalRiskCount,
-      highRiskCount,
-      totalOpenRisks,
-      lastUpdated: vendor.lastUpdated,
-      priority,
-      categoryScores: vendor.categoryScores || null,
-    };
-  }).sort(compareVendorPriority);
-}
-
-function normalizePortfolioRisks(portfolio) {
-  const grouped = new Map();
-  const allRisks = [];
-
-  for (const vendor of portfolio.vendors) {
-    for (const risk of vendor.risks || []) allRisks.push({ ...risk, vendorName: vendor.name, vendorDomain: vendor.domain });
-  }
-  for (const risk of portfolio.risks || []) allRisks.push(risk);
-
-  for (const risk of allRisks) {
-    const key = [risk.name, risk.severity, risk.category, risk.type, risk.subtype].map((v) => String(v || "").toLowerCase()).join("|");
-    if (!grouped.has(key)) {
-      grouped.set(key, {
-        id: key,
-        name: risk.name,
-        severity: normalizeSeverity(risk.severity),
-        category: risk.category || "Uncategorized",
-        type: risk.type || "—",
-        subtype: risk.subtype || "—",
-        vendors: new Set(),
-        vendorImpactCount: 0,
-        hostnames: new Set(),
-        firstDetected: risk.firstDetected || null,
-        recommendation: risk.recommendation || recommendationForRisk(risk.name, risk.category),
-      });
-    }
-    const item = grouped.get(key);
-    if (risk.vendorName || risk.vendorDomain) item.vendors.add(risk.vendorName || risk.vendorDomain);
-    item.vendorImpactCount = Math.max(item.vendorImpactCount, numberOrZero(risk.vendorsImpacted));
-    for (const host of [...(risk.hostnames || []), ...(risk.affectedHostnames || [])]) item.hostnames.add(String(host));
-    if (risk.vendorDomain) item.hostnames.add(risk.vendorDomain);
-    if (risk.firstDetected && (!item.firstDetected || new Date(risk.firstDetected) < new Date(item.firstDetected))) item.firstDetected = risk.firstDetected;
-  }
-
-  return Array.from(grouped.values()).map((risk) => ({
-    id: risk.id,
-    name: risk.name,
-    severity: risk.severity,
-    category: risk.category,
-    type: risk.type,
-    subtype: risk.subtype,
-    vendorsImpacted: Math.max(risk.vendors.size, risk.vendorImpactCount, 1),
-    affectedHostnames: Array.from(risk.hostnames).slice(0, 12),
-    firstDetected: risk.firstDetected,
-    recommendation: risk.recommendation,
-  })).sort(compareRiskPriority);
-}
-
-function normalizeRiskChanges(portfolio, days) {
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  const direct = (portfolio.changes || []).filter((change) => new Date(change.dateDetected) >= cutoff);
-  if (direct.length) return direct.sort((a, b) => new Date(b.dateDetected) - new Date(a.dateDetected));
-
-  // TODO: Replace this snapshot-derived placeholder with confirmed UpGuard risk diff/change endpoint wiring.
-  return normalizePortfolioRisks(portfolio).slice(0, 8).map((risk, index) => ({
-    id: "snapshot-" + index,
-    dateDetected: new Date(Date.now() - (index + 2) * 24 * 60 * 60 * 1000).toISOString(),
-    vendor: risk.affectedHostnames[0] || PORTFOLIO_NAME,
-    changeType: index % 4 === 0 ? "resolved risk" : (index % 3 === 0 ? "worsened" : "new risk"),
-    findingName: risk.name,
-    severity: risk.severity,
-    affectedAsset: risk.affectedHostnames[0] || "Portfolio-wide",
-  }));
-}
-
-function normalizeRemediationCampaigns(portfolio) {
-  const risks = normalizePortfolioRisks(portfolio);
+function normalizeRemediationCampaigns(risks) {
   const templates = [
-    { key: "email-auth", name: "DMARC/SPF/DKIM remediation", match: /dmarc|spf|dkim|email/i, timeframe: "30 days" },
-    { key: "tls-headers", name: "TLS/security header hardening", match: /tls|ssl|hsts|header|cipher|https/i, timeframe: "45 days" },
-    { key: "exposed-services", name: "Exposed service review", match: /port|service|rdp|ssh|ftp|exposed/i, timeframe: "14 days" },
-    { key: "cert-hygiene", name: "Certificate hygiene", match: /certificate|cert|expired/i, timeframe: "21 days" },
-    { key: "vulnerable-software", name: "Vulnerable software remediation", match: /vulnerab|cve|software|version|patch/i, timeframe: "30 days" },
+    { key: "email-auth", name: "DMARC/SPF/DKIM", match: /dmarc|spf|dkim|email/i, timeline: "30 days", action: "Validate SPF/DKIM alignment, publish enforcement-ready DMARC policy, and request evidence from affected vendors." },
+    { key: "tls-hardening", name: "TLS hardening", match: /tls|ssl|cipher|https|certificate/i, timeline: "45 days", action: "Require modern TLS, valid certificates, automated renewal, and retest evidence for affected domains." },
+    { key: "exposed-services", name: "Exposed service remediation", match: /port|service|rdp|ssh|ftp|exposed|admin/i, timeline: "14 days", action: "Escalate exposed administrative services, restrict access, and document compensating controls." },
+    { key: "security-headers", name: "Security headers", match: /header|hsts|csp|x-frame|browser/i, timeline: "30 days", action: "Request missing browser security headers and verify hardened web responses after remediation." },
+    { key: "vulnerable-software", name: "Vulnerable software", match: /vulnerab|cve|software|version|patch|outdated/i, timeline: "30 days", action: "Prioritize patch plans, exception approvals, and compensating controls for vulnerable software." },
   ];
 
   const campaigns = [];
   for (const template of templates) {
-    const matches = risks.filter((risk) => template.match.test(risk.name + " " + risk.category + " " + risk.type));
+    const matches = (risks || []).filter((risk) => template.match.test([risk.name, risk.category, risk.type, risk.subtype].join(" ")));
     if (!matches.length) continue;
     const top = matches[0];
-    const affected = matches.reduce((sum, risk) => sum + risk.vendorsImpacted, 0);
+    const affectedVendorCount = matches.reduce((sum, risk) => sum + Math.max(risk.vendorsImpacted, 1), 0);
     campaigns.push({
       id: template.key,
       name: template.name,
+      associatedFinding: top.name,
       findingAddressed: top.name,
       severity: highestSeverity(matches.map((risk) => risk.severity)),
-      affectedVendorCount: affected,
-      status: campaignStatus(top.severity, affected),
-      targetTimeframe: template.timeframe,
-      nextAction: nextActionForCampaign(template.key, affected),
+      affectedVendorCount,
+      recommendedAction: template.action,
+      nextAction: template.action,
+      status: campaignStatus(top.severity, affectedVendorCount),
+      targetTimeline: template.timeline,
+      targetTimeframe: template.timeline,
     });
   }
 
-  const covered = new Set(campaigns.map((campaign) => campaign.findingAddressed));
-  risks.filter((risk) => !covered.has(risk.name)).slice(0, 4).forEach((risk, index) => {
+  const covered = new Set(campaigns.map((campaign) => campaign.associatedFinding));
+  for (const risk of (risks || []).filter((item) => !covered.has(item.name)).slice(0, 5)) {
     campaigns.push({
-      id: "campaign-" + index,
+      id: safeFileName(risk.name),
       name: risk.category + " remediation",
+      associatedFinding: risk.name,
       findingAddressed: risk.name,
       severity: risk.severity,
       affectedVendorCount: risk.vendorsImpacted,
-      status: campaignStatus(risk.severity, risk.vendorsImpacted),
-      targetTimeframe: risk.severity === "critical" ? "14 days" : "30 days",
+      recommendedAction: risk.recommendation,
       nextAction: risk.recommendation,
+      status: campaignStatus(risk.severity, risk.vendorsImpacted),
+      targetTimeline: risk.severity === "critical" ? "14 days" : "30 days",
+      targetTimeframe: risk.severity === "critical" ? "14 days" : "30 days",
     });
-  });
+  }
 
+  // TODO(D1): store campaign lifecycle state here once remediation history persistence is added.
   return campaigns.sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || b.affectedVendorCount - a.affectedVendorCount);
 }
 
-async function handleReportRequest(req, env) {
-  let body = {};
-  try { body = await req.json(); } catch (e) { body = {}; }
-  const type = body.type || "executive_summary_pdf";
-  const reportType = REPORT_TYPES[type];
-  if (!reportType) return json({ error: "unknown_report_type", portfolioName: PORTFOLIO_NAME }, 400);
-
-  const id = "rpt_" + safeFileName(type) + "_" + Date.now();
-  const portfolioId = getConfiguredPortfolioId(env);
-  // TODO: Confirm exact UpGuard report request endpoint and payload. Portfolio report requests should pass vendor_portfolio_names and the configured portfolio identifier where the endpoint supports it.
-  return json({
-    id,
-    portfolioName: PORTFOLIO_NAME,
-    portfolioId: portfolioId || null,
-    vendor_portfolio_names: [PORTFOLIO_NAME],
-    status: "queued",
-    reportType: type,
-    label: reportType.label,
-    format: reportType.format,
-    scope: reportType.scope,
-    message: "Report request queued for " + PORTFOLIO_NAME + ". Placeholder until the confirmed UpGuard report endpoint is wired.",
-  }, 202);
+function handleReportRequest(req, env) {
+  return req.json().catch(() => ({})).then((body) => {
+    const requestedType = body.type || "ExecutiveSummaryPDF";
+    const canonicalType = REPORT_TYPES[requestedType] ? requestedType : legacyReportType(requestedType);
+    const reportType = REPORT_TYPES[canonicalType];
+    if (!reportType) return json({ error: "unknown_report_type", supportedTypes: Object.keys(REPORT_TYPES), portfolioName: PORTFOLIO_NAME }, 400);
+    const id = "rpt_" + canonicalType + "_" + Date.now();
+    return json({
+      id,
+      portfolioName: PORTFOLIO_NAME,
+      portfolioId: getConfiguredPortfolioId(env) || null,
+      status: "queued",
+      type: canonicalType,
+      label: reportType.label,
+      format: reportType.format,
+      scope: reportType.scope,
+      message: "Placeholder report request accepted. Wire this to the confirmed UpGuard report request endpoint when request formats are finalized.",
+    }, 202);
+  });
 }
 
-function generateExecutiveSummary(vendorCount, avgScore, criticalRiskCount, highRiskCount, topFinding, topCampaign) {
-  const nextStep = String(topCampaign ? topCampaign.nextAction : "validate portfolio coverage and continue monitoring risk changes").replace(/[.!?]+$/, "");
-  return "The " + PORTFOLIO_NAME + " portfolio currently has " + vendorCount + " monitored vendors with an average score of " + (avgScore == null ? "unavailable" : avgScore) + ". There are " + criticalRiskCount + " critical risks and " + highRiskCount + " high risks across the portfolio. The most common issue is " + (topFinding ? topFinding.name : "not currently available") + ", affecting " + (topFinding ? topFinding.vendorsImpacted : 0) + " vendors. Recommended next step: " + nextStep + ".";
+function reportStatus(id) {
+  return { id, portfolioName: PORTFOLIO_NAME, status: id ? "ready" : "missing_id", message: id ? "Placeholder report is ready for download." : "Provide a report id." };
+}
+
+function reportDownload(id) {
+  return new Response("Report placeholder for " + PORTFOLIO_NAME + " (" + id + "). TODO: connect to confirmed UpGuard report download endpoint.", {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Disposition": "attachment; filename=\"" + safeFileName(PORTFOLIO_NAME) + "-" + safeFileName(id) + ".txt\"",
+    },
+  });
+}
+
+function legacyReportType(type) {
+  const map = {
+    executive_summary_pdf: "ExecutiveSummaryPDF",
+    board_summary_pdf: "BoardSummaryPDF",
+    board_summary_pptx: "BoardSummaryPPTX",
+    vendor_summary_pdf: "VendorSummaryPDF",
+    vendor_detailed_pdf: "VendorDetailedPDF",
+    vendor_risk_profile_xlsx: "VendorRiskProfileXLSX",
+    vendor_vulnerabilities_overview_xlsx: "VendorVulnsOverviewXLSX",
+  };
+  return map[type] || null;
+}
+
+function generateExecutiveSummary(vendorCount, avgScore, criticalRiskCount, highRiskCount, topFinding) {
+  return "The " + PORTFOLIO_NAME + " portfolio currently contains " + vendorCount + " monitored vendors with an average security score of " + (avgScore == null ? "unavailable" : avgScore) + ". There are " + criticalRiskCount + " critical risks and " + highRiskCount + " high risks across the portfolio. The most common finding is " + (topFinding ? topFinding.name : "not currently available") + ", affecting " + (topFinding ? topFinding.vendorsImpacted : 0) + " vendors.";
 }
 
 function createSamplePortfolio() {
@@ -590,7 +509,6 @@ function createSamplePortfolio() {
     sampleVendor("v4", "Northstar Payments", "payments.northstar.example", 812, 4, "2026-05-08T12:20:00Z"),
     sampleVendor("v5", "Harbor HR Platform", "hr.harbor.example", 705, -17, "2026-05-07T14:45:00Z"),
   ];
-
   const riskTemplates = [
     ["DMARC policy not enforced", "high", "Email Security", "email", "authentication", "Publish a DMARC policy at quarantine or reject after validating SPF/DKIM alignment."],
     ["TLS certificate expires soon", "medium", "Certificate Hygiene", "tls", "certificate", "Renew certificates and confirm automated rotation for affected domains."],
@@ -598,79 +516,98 @@ function createSamplePortfolio() {
     ["Exposed remote administration service", "critical", "Network Exposure", "service", "exposed-service", "Restrict administrative ports to trusted networks and verify compensating controls."],
     ["Outdated web server version detected", "critical", "Vulnerable Software", "software", "patching", "Patch vulnerable software or place the service behind a compensating control."],
   ];
-
   vendors[0].risks.push(sampleRisk(riskTemplates[0], vendors[0], "2026-04-18"), sampleRisk(riskTemplates[3], vendors[0], "2026-05-03"), sampleRisk(riskTemplates[4], vendors[0], "2026-05-07"));
   vendors[1].risks.push(sampleRisk(riskTemplates[0], vendors[1], "2026-04-26"), sampleRisk(riskTemplates[2], vendors[1], "2026-05-01"));
   vendors[2].risks.push(sampleRisk(riskTemplates[0], vendors[2], "2026-04-12"), sampleRisk(riskTemplates[1], vendors[2], "2026-05-02"), sampleRisk(riskTemplates[2], vendors[2], "2026-05-04"));
   vendors[3].risks.push(sampleRisk(riskTemplates[1], vendors[3], "2026-04-28"));
   vendors[4].risks.push(sampleRisk(riskTemplates[2], vendors[4], "2026-04-23"), sampleRisk(riskTemplates[4], vendors[4], "2026-05-06"));
-
-  return {
-    portfolioName: PORTFOLIO_NAME,
-    portfolioId: "sample-commonwealth-common-vendors",
-    source: "sample",
-    warning: null,
-    vendors,
-    risks: vendors.flatMap((vendor) => vendor.risks),
-    changes: [
-      sampleChange("2026-05-09T12:10:00Z", "Acme Payroll Services", "new risk", "Outdated web server version detected", "critical", "payroll.acme.example"),
-      sampleChange("2026-05-08T15:35:00Z", "Harbor HR Platform", "worsened", "Security headers missing", "high", "hr.harbor.example"),
-      sampleChange("2026-05-07T09:22:00Z", "CivicNotify", "resolved risk", "TLS certificate expires soon", "medium", "notify.civic.example"),
-      sampleChange("2026-05-04T20:18:00Z", "Beacon Records Cloud", "new risk", "Security headers missing", "high", "records.beacon.example"),
-      sampleChange("2026-05-03T08:44:00Z", "Acme Payroll Services", "new risk", "Exposed remote administration service", "critical", "payroll.acme.example"),
-      sampleChange("2026-04-30T13:00:00Z", "Northstar Payments", "improved", "DMARC policy not enforced", "high", "payments.northstar.example"),
-    ],
-  };
+  return { portfolioName: PORTFOLIO_NAME, portfolioId: "sample-commonwealth-common-vendors", source: "sample", vendors, risks: vendors.flatMap((vendor) => vendor.risks) };
 }
 
 function sampleVendor(id, name, domain, score, trend30d, lastUpdated) {
-  return {
-    id, name, domain, score, trend30d, lastUpdated,
-    categoryScores: { website: score + 22, email: score - 64, network: score - 18, brand: score + 40 },
-    risks: [],
-  };
+  return { id, name, domain, score, trend30d, lastUpdated, categoryScores: { website: score + 8, email: score - 20, network: score - 12, phishing: score + 15 }, risks: [] };
 }
 
 function sampleRisk(template, vendor, firstDetected) {
-  return {
-    id: vendor.id + "-" + template[0].toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-    name: template[0],
-    severity: template[1],
-    category: template[2],
-    type: template[3],
-    subtype: template[4],
-    vendorsImpacted: 1,
-    hostnames: [vendor.domain],
-    firstDetected,
-    recommendation: template[5],
-    vendorName: vendor.name,
-    vendorDomain: vendor.domain,
-    status: "open",
-  };
+  return { id: safeFileName(template[0] + "-" + vendor.domain), name: template[0], severity: template[1], category: template[2], type: template[3], subtype: template[4], vendorsImpacted: 1, affectedHostnames: [vendor.domain], hostnames: [vendor.domain], firstDetected, recommendation: template[5], vendorName: vendor.name, vendorDomain: vendor.domain, status: "open" };
+}
+
+function withSampleRiskProfileWarning(portfolioId, code, message) {
+  return normalizePortfolioRiskProfilePages([{ total_vendors: SAMPLE_PORTFOLIO.vendors.length, risks: SAMPLE_PORTFOLIO.risks }], portfolioId || SAMPLE_PORTFOLIO.portfolioId, "sample", { code, message });
+}
+
+function missingConfigWarning(env) {
+  if (!String((env || {}).UPGUARD_API_KEY || "").trim()) return { code: "missing_api_key", message: "UPGUARD_API_KEY is not configured; showing sample data." };
+  return { code: "missing_portfolio_id", message: "UPGUARD_PORTFOLIO_ID is not configured; showing sample data." };
+}
+
+function normalizeSampleVendorSummaries() {
+  return SAMPLE_PORTFOLIO.vendors.map((vendor) => {
+    const criticalRiskCount = vendor.risks.filter((risk) => risk.severity === "critical").length;
+    const highRiskCount = vendor.risks.filter((risk) => risk.severity === "high").length;
+    const summary = { id: vendor.id, name: vendor.name, domain: vendor.domain, score: vendor.score, trend30d: vendor.trend30d, criticalRiskCount, highRiskCount, totalOpenRisks: vendor.risks.length, lastUpdated: vendor.lastUpdated, categoryScores: vendor.categoryScores, activeFindings: vendor.risks, recentChanges: sampleChanges(30).filter((change) => change.vendor === vendor.name) };
+    summary.priority = priorityForVendor(summary);
+    return summary;
+  }).sort(compareVendorPriority);
+}
+
+function vendorDetailFromSample(hostname) {
+  const vendor = SAMPLE_PORTFOLIO.vendors.find((item) => item.domain === hostname || item.name === hostname) || SAMPLE_PORTFOLIO.vendors[0];
+  return { ...vendor, activeFindings: vendor.risks, recentChanges: sampleChanges(30).filter((change) => change.vendor === vendor.name), riskHistory: null, source: "sample", warning: null };
+}
+
+function sampleChanges(days) {
+  return [
+    sampleChange("2026-05-09T12:10:00Z", "Acme Payroll Services", "New Risk", "Outdated web server version detected", "critical", "payroll.acme.example"),
+    sampleChange("2026-05-08T15:35:00Z", "Harbor HR Platform", "Severity Increased", "Security headers missing", "high", "hr.harbor.example"),
+    sampleChange("2026-05-07T09:22:00Z", "CivicNotify", "Resolved Risk", "TLS certificate expires soon", "medium", "notify.civic.example"),
+    sampleChange("2026-05-04T20:18:00Z", "Beacon Records Cloud", "New Risk", "Security headers missing", "high", "records.beacon.example"),
+    sampleChange("2026-05-03T08:44:00Z", "Acme Payroll Services", "New Risk", "Exposed remote administration service", "critical", "payroll.acme.example"),
+  ].filter((change) => new Date(change.dateDetected) >= new Date(Date.now() - days * 24 * 60 * 60 * 1000)).sort(sortNewestChangeFirst);
 }
 
 function sampleChange(dateDetected, vendor, changeType, findingName, severity, affectedAsset) {
-  return { id: dateDetected + findingName, dateDetected, vendor, changeType, findingName, severity, affectedAsset };
+  return { id: dateDetected + findingName, date: dateDetected, dateDetected, vendor, changeType, finding: findingName, findingName, severity, affectedHostname: affectedAsset, affectedAsset };
 }
 
-function withSampleWarning(code, message) {
-  return { ...SAMPLE_PORTFOLIO, source: "sample", warning: { code, message } };
+function hostListFromValue(value) {
+  if (!value) return [];
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(hostListFromValue);
+  if (typeof value === "object") return [value.hostname, value.domain, value.primary_hostname, value.name].filter(Boolean);
+  return [];
+}
+
+function countBy(items, field, weightByVendors) {
+  return (items || []).reduce((counts, item) => {
+    const key = item[field] || "Uncategorized";
+    counts[key] = (counts[key] || 0) + (weightByVendors ? Math.max(numberOrZero(item.vendorsImpacted), 1) : 1);
+    return counts;
+  }, {});
+}
+
+function deriveVendorCount(risks) {
+  return new Set((risks || []).flatMap((risk) => risk.affectedHostnames || [])).size;
 }
 
 function priorityForVendor(vendor) {
-  if (vendor.criticalRiskCount > 0) return "Critical";
-  if (vendor.highRiskCount >= 2 || (vendor.highRiskCount > 0 && vendor.score < PORTFOLIO_THRESHOLD)) return "High";
-  if (vendor.highRiskCount > 0 || vendor.score < PORTFOLIO_THRESHOLD || vendor.trend30d <= -15) return "Medium";
+  if (vendor.criticalRiskCount > 0 || (vendor.highRiskCount >= 3 && vendor.score !== null && vendor.score < PORTFOLIO_THRESHOLD)) return "Critical";
+  if (vendor.highRiskCount >= 2 || (vendor.highRiskCount > 0 && vendor.score !== null && vendor.score < PORTFOLIO_THRESHOLD)) return "High";
+  if (vendor.highRiskCount > 0 || (vendor.score !== null && vendor.score < PORTFOLIO_THRESHOLD) || vendor.trend30d <= -15) return "Medium";
   return "Monitor";
 }
 
 function compareVendorPriority(a, b) {
   const order = { Critical: 4, High: 3, Medium: 2, Monitor: 1 };
-  return (order[b.priority] - order[a.priority]) || (b.criticalRiskCount - a.criticalRiskCount) || (b.highRiskCount - a.highRiskCount) || ((a.score || 0) - (b.score || 0)) || ((a.trend30d || 0) - (b.trend30d || 0));
+  return (order[b.priority] - order[a.priority]) || (b.criticalRiskCount - a.criticalRiskCount) || (b.highRiskCount - a.highRiskCount) || ((a.score ?? 1000) - (b.score ?? 1000)) || ((a.trend30d || 0) - (b.trend30d || 0));
 }
 
 function compareRiskPriority(a, b) {
   return severityRank(b.severity) - severityRank(a.severity) || b.vendorsImpacted - a.vendorsImpacted || a.name.localeCompare(b.name);
+}
+
+function sortNewestChangeFirst(a, b) {
+  return new Date(b.dateDetected || b.date) - new Date(a.dateDetected || a.date);
 }
 
 function severityRank(severity) {
@@ -689,15 +626,14 @@ function normalizeSeverity(severity) {
 
 function normalizeChangeType(type) {
   const value = String(type || "new risk").toLowerCase().replace(/_/g, " ");
-  if (value.includes("resolv") || value.includes("fixed")) return "resolved risk";
-  if (value.includes("wors")) return "worsened";
-  if (value.includes("improv")) return "improved";
-  if (value.includes("new")) return "new risk";
-  return value;
+  if (value.includes("resolv") || value.includes("fixed") || value.includes("closed")) return "Resolved Risk";
+  if (value.includes("wors") || value.includes("increas") || value.includes("escalat")) return "Severity Increased";
+  if (value.includes("improv") || value.includes("reduc") || value.includes("decreas")) return "Severity Reduced";
+  return "New Risk";
 }
 
 function highestSeverity(severities) {
-  return severities.sort((a, b) => severityRank(b) - severityRank(a))[0] || "medium";
+  return (severities || []).sort((a, b) => severityRank(b) - severityRank(a))[0] || "medium";
 }
 
 function campaignStatus(severity, affectedCount) {
@@ -706,38 +642,14 @@ function campaignStatus(severity, affectedCount) {
   return "Not Started";
 }
 
-function nextActionForCampaign(key, affected) {
-  const noun = affected === 1 ? "vendor" : "vendors";
-  const actions = {
-    "email-auth": "Send a shared DMARC/SPF/DKIM remediation brief to " + affected + " affected " + noun + " and request target policy dates.",
-    "tls-headers": "Open hardening tickets for affected web properties and validate TLS/header configuration after remediation.",
-    "exposed-services": "Escalate exposed administrative services for immediate access restriction and compensating control review.",
-    "cert-hygiene": "Request certificate renewal evidence and confirm automated expiration monitoring.",
-    "vulnerable-software": "Prioritize patch plans for vulnerable software and track exception approvals where patching is delayed.",
-  };
-  return actions[key] || "Assign owners, request evidence, and track remediation progress weekly.";
-}
-
 function recommendationForRisk(name, category) {
   const value = String(name + " " + category).toLowerCase();
   if (/dmarc|spf|dkim|email/.test(value)) return "Validate SPF/DKIM alignment and move DMARC toward quarantine or reject.";
   if (/tls|ssl|certificate|cert/.test(value)) return "Renew certificates and enforce modern TLS configuration.";
   if (/header|hsts|csp/.test(value)) return "Add missing browser security headers and retest affected hosts.";
   if (/port|service|exposed|rdp|ssh/.test(value)) return "Restrict exposed services and verify access controls.";
-  if (/vulnerab|cve|software|patch/.test(value)) return "Patch vulnerable software or document compensating controls.";
+  if (/vulnerab|cve|software|patch|outdated/.test(value)) return "Patch vulnerable software or document compensating controls.";
   return "Assign an owner, request vendor remediation evidence, and verify closure in UpGuard.";
-}
-
-function asArray(value, keys) {
-  if (Array.isArray(value)) return value;
-  if (typeof value === "string") return value ? [value] : [];
-  if (Array.isArray(keys)) {
-    for (const key of keys) {
-      if (value && Array.isArray(value[key])) return value[key];
-    }
-  }
-  if (value && typeof value === "object") return Object.values(value).filter((item) => item && typeof item === "object");
-  return [];
 }
 
 function numberOrNull(value) {
@@ -761,10 +673,7 @@ function safeFileName(value) {
 }
 
 function json(obj, status = 200) {
-  return new Response(JSON.stringify(obj), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" },
-  });
+  return new Response(JSON.stringify(obj), { status, headers: { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" } });
 }
 
 function renderPage() {
@@ -773,227 +682,48 @@ function renderPage() {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Commonwealth Common Vendors | UpGuard Portfolio Intelligence</title>
+  <title>${PORTFOLIO_NAME} | Portfolio Cyber Risk Intelligence</title>
   <style>
-    :root { color-scheme: light; --bg:#f4f7fb; --ink:#0f172a; --muted:#64748b; --panel:#ffffff; --line:#e2e8f0; --brand:#1d4ed8; --brand2:#0f766e; --danger:#dc2626; --warn:#d97706; --ok:#059669; --shadow:0 18px 45px rgba(15,23,42,.10); }
-    * { box-sizing:border-box; }
-    body { margin:0; background:radial-gradient(circle at 20% 0%, rgba(59,130,246,.18), transparent 34%), var(--bg); color:var(--ink); font-family:Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { background:linear-gradient(135deg, #07152f 0%, #123f7a 58%, #0f766e 100%); color:#fff; padding:28px 24px 76px; position:relative; overflow:hidden; }
-    header:after { content:""; position:absolute; inset:auto -10% -55% 35%; height:220px; background:rgba(255,255,255,.09); filter:blur(6px); transform:rotate(-8deg); }
-    .wrap { max-width:1240px; margin:0 auto; position:relative; z-index:1; }
-    .eyebrow { display:inline-flex; gap:8px; align-items:center; padding:6px 10px; border:1px solid rgba(255,255,255,.25); border-radius:999px; background:rgba(255,255,255,.10); font-size:12px; letter-spacing:.08em; text-transform:uppercase; }
-    h1 { margin:16px 0 8px; font-size:clamp(30px, 5vw, 54px); line-height:1; letter-spacing:-.04em; }
-    .sub { max-width:860px; color:rgba(255,255,255,.84); font-size:17px; line-height:1.55; }
-    .portfolio-pill { display:inline-flex; gap:8px; align-items:center; margin-top:18px; padding:10px 14px; background:rgba(255,255,255,.15); border:1px solid rgba(255,255,255,.22); border-radius:14px; font-weight:800; }
-    main { max-width:1240px; margin:-48px auto 40px; padding:0 20px; position:relative; z-index:2; }
-    .shell { background:rgba(255,255,255,.86); backdrop-filter:blur(14px); border:1px solid rgba(226,232,240,.9); border-radius:24px; box-shadow:var(--shadow); overflow:hidden; }
-    .statusbar { display:flex; justify-content:space-between; gap:16px; align-items:center; padding:16px 18px; border-bottom:1px solid var(--line); background:rgba(248,250,252,.74); }
-    .status { font-size:13px; color:var(--muted); }
-    .status strong { color:var(--ink); }
-    .warning { color:#92400e; background:#fffbeb; border:1px solid #fde68a; padding:8px 10px; border-radius:12px; }
-    .tabs { display:flex; gap:4px; padding:10px; overflow:auto; border-bottom:1px solid var(--line); }
-    .tab { white-space:nowrap; border:0; background:transparent; color:var(--muted); padding:11px 14px; border-radius:13px; font-weight:800; cursor:pointer; }
-    .tab.active { background:#dbeafe; color:#1d4ed8; }
-    .content { padding:20px; }
-    .grid { display:grid; gap:16px; }
-    .metrics { grid-template-columns:repeat(4, minmax(0, 1fr)); }
-    .two { grid-template-columns:1.2fr .8fr; align-items:start; }
-    .card { background:var(--panel); border:1px solid var(--line); border-radius:20px; padding:18px; box-shadow:0 8px 22px rgba(15,23,42,.05); }
-    .metric .label { color:var(--muted); font-size:13px; font-weight:800; text-transform:uppercase; letter-spacing:.04em; }
-    .metric .value { font-size:34px; font-weight:900; margin-top:8px; letter-spacing:-.04em; }
-    .metric .hint { color:var(--muted); font-size:13px; margin-top:4px; }
-    .summary { font-size:17px; line-height:1.7; color:#1e293b; }
-    .section-title { display:flex; justify-content:space-between; gap:12px; align-items:center; margin:0 0 14px; }
-    .section-title h2 { margin:0; font-size:20px; letter-spacing:-.02em; }
-    .filters { display:flex; flex-wrap:wrap; gap:10px; margin-bottom:14px; }
-    input, select { border:1px solid var(--line); background:#fff; border-radius:12px; padding:10px 12px; color:var(--ink); min-width:180px; }
-    table { width:100%; border-collapse:separate; border-spacing:0; overflow:hidden; }
-    th { text-align:left; font-size:12px; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; border-bottom:1px solid var(--line); padding:12px; background:#f8fafc; cursor:pointer; }
-    td { border-bottom:1px solid #edf2f7; padding:13px 12px; vertical-align:top; font-size:14px; }
-    tr:last-child td { border-bottom:0; }
-    .table-wrap { overflow:auto; border:1px solid var(--line); border-radius:18px; }
-    .badge { display:inline-flex; align-items:center; justify-content:center; border-radius:999px; padding:4px 9px; font-size:12px; font-weight:900; text-transform:capitalize; }
-    .critical { color:#991b1b; background:#fee2e2; } .high { color:#9a3412; background:#ffedd5; } .medium { color:#854d0e; background:#fef3c7; } .low, .monitor { color:#166534; background:#dcfce7; } .informational { color:#334155; background:#e2e8f0; }
-    .priority-Critical { color:#991b1b; background:#fee2e2; } .priority-High { color:#9a3412; background:#ffedd5; } .priority-Medium { color:#854d0e; background:#fef3c7; } .priority-Monitor { color:#166534; background:#dcfce7; }
-    .trend-pos { color:var(--ok); font-weight:900; } .trend-neg { color:var(--danger); font-weight:900; } .muted { color:var(--muted); }
-    .campaigns { grid-template-columns:repeat(2, minmax(0, 1fr)); }
-    .campaign { display:grid; gap:10px; }
-    .campaign h3 { margin:0; font-size:18px; }
-    .btn { border:0; border-radius:14px; padding:11px 14px; background:#1d4ed8; color:white; font-weight:900; cursor:pointer; }
-    .btn.secondary { background:#e0f2fe; color:#075985; }
-    .reports { grid-template-columns:repeat(3, minmax(0, 1fr)); }
-    .report { display:grid; gap:12px; }
-    .empty { padding:28px; text-align:center; color:var(--muted); }
-    .loading { min-height:180px; display:grid; place-items:center; color:var(--muted); }
-    .spark { display:flex; height:58px; gap:7px; align-items:end; }
-    .spark span { flex:1; min-width:10px; background:linear-gradient(180deg, #60a5fa, #0f766e); border-radius:8px 8px 2px 2px; }
-    .host-list { color:var(--muted); max-width:360px; }
-    footer { max-width:1240px; margin:0 auto 34px; padding:0 20px; color:var(--muted); font-size:13px; }
-    @media (max-width: 980px) { .metrics, .two, .campaigns, .reports { grid-template-columns:1fr 1fr; } }
-    @media (max-width: 700px) { header { padding-bottom:64px; } main { padding:0 12px; } .metrics, .two, .campaigns, .reports { grid-template-columns:1fr; } .statusbar { align-items:flex-start; flex-direction:column; } .content { padding:14px; } }
+    :root{color-scheme:light dark;--bg:#eef4fb;--ink:#0f172a;--muted:#64748b;--panel:#fff;--line:#dbe4ef;--brand:#1d4ed8;--brand2:#0f766e;--danger:#dc2626;--warn:#d97706;--ok:#059669;--shadow:0 18px 45px rgba(15,23,42,.12)}
+    @media (prefers-color-scheme:dark){:root{--bg:#07111f;--ink:#e5edf7;--muted:#95a3b8;--panel:#0f1b2d;--line:#22324a;--brand:#60a5fa;--brand2:#2dd4bf;--shadow:0 18px 45px rgba(0,0,0,.35)}}
+    *{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 20% 0%,rgba(59,130,246,.20),transparent 34%),var(--bg);color:var(--ink);font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif}header{background:linear-gradient(135deg,#061226 0%,#123f7a 58%,#0f766e 100%);color:#fff;padding:30px 24px 82px;position:relative;overflow:hidden}header:after{content:"";position:absolute;inset:auto -10% -55% 35%;height:220px;background:rgba(255,255,255,.09);filter:blur(6px);transform:rotate(-8deg)}.wrap{max-width:1280px;margin:0 auto;position:relative;z-index:1}.eyebrow{display:inline-flex;gap:8px;align-items:center;padding:6px 10px;border:1px solid rgba(255,255,255,.25);border-radius:999px;background:rgba(255,255,255,.10);font-size:12px;letter-spacing:.08em;text-transform:uppercase}h1{margin:16px 0 8px;font-size:clamp(30px,5vw,56px);line-height:1;letter-spacing:-.04em}.sub{max-width:900px;color:rgba(255,255,255,.84);font-size:17px;line-height:1.55}.portfolio-pill{display:inline-flex;gap:8px;align-items:center;margin-top:18px;padding:10px 14px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.22);border-radius:14px;font-weight:800}main{max-width:1280px;margin:-52px auto 40px;padding:0 20px;position:relative;z-index:2}.shell{background:color-mix(in srgb,var(--panel) 88%,transparent);backdrop-filter:blur(14px);border:1px solid var(--line);border-radius:24px;box-shadow:var(--shadow);overflow:hidden}.statusbar{display:flex;justify-content:space-between;gap:16px;align-items:center;padding:16px 18px;border-bottom:1px solid var(--line);background:color-mix(in srgb,var(--panel) 74%,transparent)}.status{font-size:13px;color:var(--muted)}.status strong{color:var(--ink)}.warning{color:#92400e;background:#fffbeb;border:1px solid #fde68a;padding:8px 10px;border-radius:12px}.tabs{display:flex;gap:4px;padding:10px;overflow:auto;border-bottom:1px solid var(--line)}.tab{white-space:nowrap;border:0;background:transparent;color:var(--muted);padding:11px 14px;border-radius:13px;font-weight:800;cursor:pointer}.tab.active{background:rgba(59,130,246,.17);color:var(--brand)}.content{padding:20px}.grid{display:grid;gap:16px}.metrics{grid-template-columns:repeat(4,minmax(0,1fr))}.two{grid-template-columns:1.2fr .8fr;align-items:start}.card{background:var(--panel);border:1px solid var(--line);border-radius:20px;padding:18px;box-shadow:0 8px 22px rgba(15,23,42,.05)}.metric .label{color:var(--muted);font-size:13px;font-weight:800;text-transform:uppercase;letter-spacing:.04em}.metric .value{font-size:34px;font-weight:900;margin-top:8px;letter-spacing:-.04em}.metric .hint{color:var(--muted);font-size:13px;margin-top:4px}.summary{font-size:17px;line-height:1.7}.section-title{display:flex;justify-content:space-between;gap:12px;align-items:center;margin:0 0 14px}.section-title h2{margin:0;font-size:20px;letter-spacing:-.02em}.filters{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:14px}input,select{border:1px solid var(--line);background:var(--panel);border-radius:12px;padding:10px 12px;color:var(--ink);min-width:180px}table{width:100%;border-collapse:separate;border-spacing:0;overflow:hidden}th{text-align:left;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid var(--line);padding:12px;background:color-mix(in srgb,var(--panel) 84%,var(--bg));cursor:pointer}td{border-bottom:1px solid var(--line);padding:13px 12px;vertical-align:top;font-size:14px}tr:last-child td{border-bottom:0}.table-wrap{overflow:auto;border:1px solid var(--line);border-radius:18px}.badge{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;padding:4px 9px;font-size:12px;font-weight:900;text-transform:capitalize}.critical{color:#991b1b;background:#fee2e2}.high{color:#9a3412;background:#ffedd5}.medium{color:#854d0e;background:#fef3c7}.low,.monitor{color:#166534;background:#dcfce7}.informational{color:#334155;background:#e2e8f0}.priority-Critical{color:#991b1b;background:#fee2e2}.priority-High{color:#9a3412;background:#ffedd5}.priority-Medium{color:#854d0e;background:#fef3c7}.priority-Monitor{color:#166534;background:#dcfce7}.trend-pos{color:var(--ok);font-weight:900}.trend-neg{color:var(--danger);font-weight:900}.muted{color:var(--muted)}.empty{text-align:center;color:var(--muted);padding:28px}.risk-detail{display:none;background:color-mix(in srgb,var(--panel) 72%,var(--bg));border-radius:14px;padding:12px;margin-top:8px}.risk-row.open .risk-detail{display:block}.chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}.chip{font-size:12px;color:var(--muted);border:1px solid var(--line);border-radius:999px;padding:3px 8px}.btn{border:0;border-radius:12px;background:var(--brand);color:#fff;font-weight:900;padding:10px 12px;cursor:pointer}.campaigns,.reports{grid-template-columns:repeat(3,minmax(0,1fr))}.loading{padding:34px;text-align:center;color:var(--muted)}.drawer{position:fixed;inset:0;background:rgba(2,6,23,.55);display:none;align-items:stretch;justify-content:flex-end;z-index:10}.drawer.open{display:flex}.drawer-panel{width:min(560px,100%);background:var(--panel);padding:22px;overflow:auto}.close{float:right;background:transparent;border:1px solid var(--line);color:var(--ink);border-radius:10px;padding:8px;cursor:pointer}@media(max-width:900px){.metrics,.two,.campaigns,.reports{grid-template-columns:1fr}.statusbar{align-items:flex-start;flex-direction:column}}
   </style>
 </head>
 <body>
-  <header>
-    <div class="wrap">
-      <div class="eyebrow">UpGuard Portfolio Intelligence</div>
-      <h1>Portfolio risk command center</h1>
-      <div class="sub">Actionable common-risk analytics, prioritized vendor remediation, recent changes, campaigns, and report workflows scoped only to the active UpGuard portfolio.</div>
-      <div class="portfolio-pill">Active portfolio: <span id="portfolioName">${PORTFOLIO_NAME}</span></div>
-    </div>
-  </header>
-
-  <main>
-    <section class="shell">
-      <div class="statusbar">
-        <div class="status"><strong>${PORTFOLIO_NAME}</strong> is the primary portfolio context for every dashboard view and API request.</div>
-        <div id="dataStatus" class="status">Loading portfolio intelligence…</div>
-      </div>
-      <nav class="tabs" aria-label="Dashboard sections">
-        <button class="tab active" data-tab="overview">Overview</button>
-        <button class="tab" data-tab="risks">Common Risks</button>
-        <button class="tab" data-tab="vendors">Vendors</button>
-        <button class="tab" data-tab="changes">Changes</button>
-        <button class="tab" data-tab="campaigns">Remediation Campaigns</button>
-        <button class="tab" data-tab="reports">Reports</button>
-      </nav>
-      <div id="content" class="content"><div class="loading">Loading Commonwealth Common Vendors portfolio intelligence…</div></div>
-    </section>
-  </main>
-
-  <footer>All routes explicitly scope data to <strong>${PORTFOLIO_NAME}</strong>. Mock states appear only when credentials, portfolio access, or an UpGuard endpoint is unavailable.</footer>
-
-  <script>
-    var PORTFOLIO_NAME = ${JSON.stringify(PORTFOLIO_NAME)};
-    var state = { activeTab: 'overview', overview: null, risks: [], vendors: [], changes: [], campaigns: [], sort: {}, filters: { severity: 'all', category: 'all', search: '' } };
-    var content = document.getElementById('content');
-    var dataStatus = document.getElementById('dataStatus');
-
-    function el(tag, className, text) { var node = document.createElement(tag); if (className) node.className = className; if (text !== undefined) node.textContent = text; return node; }
-    function fmt(value) { return value === null || value === undefined || value === '' ? '—' : value; }
-    function dateFmt(value) { if (!value) return '—'; try { return new Date(value).toLocaleDateString(undefined, { month:'short', day:'numeric', year:'numeric' }); } catch(e) { return value; } }
-    function badge(value, prefix) { var span = el('span', 'badge ' + (prefix || '') + String(value || '').replace(/\s+/g, '-'), value || '—'); return span; }
-    function sev(value) { return badge(value || 'medium', String(value || 'medium').toLowerCase()); }
-    function trend(value) { var n = Number(value || 0); var s = n > 0 ? '+' + n : String(n); return '<span class="' + (n < 0 ? 'trend-neg' : n > 0 ? 'trend-pos' : 'muted') + '">' + s + '</span>'; }
-    function escapeHtml(value) { return String(value == null ? '' : value).replace(/[&<>"']/g, function(ch){ return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]); }); }
-
-    function api(path, fallback) {
-      return fetch(path).then(function(res){ if (!res.ok) throw new Error('HTTP ' + res.status); return res.json(); }).catch(function(){ return fallback; });
-    }
-
-    function loadAll() {
-      Promise.all([
-        api('/api/portfolio/risk-profile', { portfolioName: PORTFOLIO_NAME, totalVendors: 5, risks: sampleRisks(), severityCounts: {}, categoryCounts: {}, topRisks: sampleRisks(), source: 'client-sample', warning: { message: 'Client sample fallback.' } }),
-        api('/api/portfolio/overview', sampleOverview()),
-        api('/api/portfolio/vendors', { portfolioName: PORTFOLIO_NAME, vendors: sampleVendors(), source: 'client-sample' }),
-        api('/api/portfolio/changes?days=30', { portfolioName: PORTFOLIO_NAME, changes: sampleChanges(), source: 'client-sample' }),
-        api('/api/portfolio/campaigns', { portfolioName: PORTFOLIO_NAME, campaigns: sampleCampaigns(), source: 'client-sample' })
-      ]).then(function(results){
-        state.overview = results[1]; state.risks = results[0].risks || []; state.vendors = results[2].vendors || []; state.changes = results[3].changes || []; state.campaigns = results[4].campaigns || [];
-        var warning = results.find(function(r){ return r && r.warning; });
-        dataStatus.innerHTML = warning ? '<span class="warning">' + escapeHtml(warning.warning.message || 'Sample fallback active') + '</span>' : 'Live or normalized data loaded for <strong>' + PORTFOLIO_NAME + '</strong>';
-        render();
-      });
-    }
-
-    document.querySelectorAll('.tab').forEach(function(btn){ btn.onclick = function(){ document.querySelectorAll('.tab').forEach(function(b){ b.classList.remove('active'); }); btn.classList.add('active'); state.activeTab = btn.dataset.tab; render(); }; });
-
-    function render() {
-      if (state.activeTab === 'overview') renderOverview();
-      if (state.activeTab === 'risks') renderRisks();
-      if (state.activeTab === 'vendors') renderVendors();
-      if (state.activeTab === 'changes') renderChanges();
-      if (state.activeTab === 'campaigns') renderCampaigns();
-      if (state.activeTab === 'reports') renderReports();
-    }
-
-    function renderOverview() {
-      var o = state.overview || sampleOverview();
-      content.innerHTML = '';
-      var metrics = el('div', 'grid metrics');
-      [
-        ['Average vendor score', fmt(o.averageScore), 'Weighted across monitored vendors'],
-        ['Monitored vendors', fmt(o.vendorCount), 'Scoped to ' + PORTFOLIO_NAME],
-        ['Critical risks', fmt(o.criticalRiskCount), 'Portfolio-wide operational priority'],
-        ['High risks', fmt(o.highRiskCount), 'Open high-severity exposure'],
-        ['Below threshold', fmt(o.vendorsBelowThreshold), 'Vendors under score threshold'],
-        ['New risks / 30d', fmt(o.newlyIntroduced30d), 'New or worsened findings'],
-        ['Remediated / 30d', fmt(o.remediated30d), 'Resolved or improved findings'],
-        ['Top common issue', fmt(o.topFindingAffectedVendorCount), fmt(o.topFindingName)]
-      ].forEach(function(m){ var card = el('div','card metric'); card.innerHTML = '<div class="label">'+escapeHtml(m[0])+'</div><div class="value">'+escapeHtml(m[1])+'</div><div class="hint">'+escapeHtml(m[2])+'</div>'; metrics.appendChild(card); });
-      content.appendChild(metrics);
-
-      var two = el('div','grid two'); two.style.marginTop = '16px';
-      var summary = el('div','card'); summary.innerHTML = '<div class="section-title"><h2>Executive summary</h2></div><div class="summary">'+escapeHtml(o.executiveSummary)+'</div>';
-      var spark = el('div','card'); spark.innerHTML = '<div class="section-title"><h2>Operational risk pulse</h2></div><div class="spark">'+state.vendors.slice(0,8).map(function(v){ return '<span title="'+escapeHtml(v.name)+'" style="height:'+Math.max(12, Math.min(58, 70 - ((v.score || 650)-500)/8))+'px"></span>'; }).join('')+'</div><p class="muted">Bars emphasize lower scores and higher remediation attention across the portfolio.</p>';
-      two.appendChild(summary); two.appendChild(spark); content.appendChild(two);
-    }
-
-    function renderRisks() {
-      content.innerHTML = '<div class="section-title"><h2>Common Risks</h2><span class="muted">Portfolio Risk Profile for '+escapeHtml(PORTFOLIO_NAME)+'</span></div>';
-      var filters = el('div','filters');
-      var categories = Array.from(new Set(state.risks.map(function(r){ return r.category; }).filter(Boolean))).sort();
-      filters.innerHTML = '<select id="severityFilter"><option value="all">All severities</option><option value="critical">Critical</option><option value="high">High</option><option value="medium">Medium</option><option value="low">Low</option></select><select id="categoryFilter"><option value="all">All categories</option>'+categories.map(function(c){ return '<option>'+escapeHtml(c)+'</option>'; }).join('')+'</select><input id="riskSearch" placeholder="Search findings, hosts, recommendations" />';
-      content.appendChild(filters);
-      filters.querySelector('#severityFilter').value = state.filters.severity; filters.querySelector('#categoryFilter').value = state.filters.category; filters.querySelector('#riskSearch').value = state.filters.search;
-      filters.oninput = function(){ state.filters.severity = filters.querySelector('#severityFilter').value; state.filters.category = filters.querySelector('#categoryFilter').value; state.filters.search = filters.querySelector('#riskSearch').value.toLowerCase(); drawRiskTable(); };
-      drawRiskTable();
-    }
-
-    function drawRiskTable() {
-      var old = document.getElementById('riskTable'); if (old) old.remove();
-      var rows = state.risks.filter(function(r){ var text = JSON.stringify(r).toLowerCase(); return (state.filters.severity === 'all' || r.severity === state.filters.severity) && (state.filters.category === 'all' || r.category === state.filters.category) && (!state.filters.search || text.indexOf(state.filters.search) >= 0); });
-      var wrap = tableWrap('riskTable', ['Finding / risk', 'Severity', 'Category', 'Type / subtype', 'Vendors impacted', 'Affected hostnames/domains', 'First detected', 'Action recommendation']);
-      var tbody = wrap.querySelector('tbody');
-      rows.forEach(function(r){ var tr = document.createElement('tr'); tr.innerHTML = '<td><strong>'+escapeHtml(r.name)+'</strong></td><td></td><td>'+escapeHtml(r.category)+'</td><td>'+escapeHtml((r.type || '—')+' / '+(r.subtype || '—'))+'</td><td><strong>'+escapeHtml(r.vendorsImpacted)+'</strong></td><td class="host-list">'+escapeHtml((r.affectedHostnames || []).join(', ') || '—')+'</td><td>'+escapeHtml(dateFmt(r.firstDetected))+'</td><td>'+escapeHtml(r.recommendation)+'</td>'; tr.children[1].appendChild(sev(r.severity)); tbody.appendChild(tr); });
-      if (!rows.length) tbody.appendChild(emptyRow(8, 'No matching common risks for this portfolio.'));
-      content.appendChild(wrap);
-    }
-
-    function renderVendors() {
-      content.innerHTML = '<div class="section-title"><h2>Vendors ranked by remediation priority</h2><span class="muted">Critical risks, high risks, score, and 30-day trend determine priority.</span></div>';
-      var wrap = tableWrap('vendorsTable', ['Vendor', 'Score', '30-day trend', 'Critical risks', 'High risks', 'Total open risks', 'Last updated', 'Recommended priority']);
-      var tbody = wrap.querySelector('tbody');
-      state.vendors.forEach(function(v){ var tr = document.createElement('tr'); tr.innerHTML = '<td><strong>'+escapeHtml(v.name)+'</strong><div class="muted">'+escapeHtml(v.domain)+'</div></td><td><strong>'+escapeHtml(fmt(v.score))+'</strong></td><td>'+trend(v.trend30d)+'</td><td>'+escapeHtml(v.criticalRiskCount)+'</td><td>'+escapeHtml(v.highRiskCount)+'</td><td>'+escapeHtml(v.totalOpenRisks)+'</td><td>'+escapeHtml(dateFmt(v.lastUpdated))+'</td><td></td>'; tr.children[7].appendChild(badge(v.priority, 'priority-')); tbody.appendChild(tr); });
-      content.appendChild(wrap);
-    }
-
-    function renderChanges() {
-      content.innerHTML = '<div class="section-title"><h2>30-day risk change feed</h2><span class="muted">New, resolved, worsened, and improved findings.</span></div>';
-      var wrap = tableWrap('changesTable', ['Date detected', 'Vendor', 'Change type', 'Risk / finding', 'Severity', 'Affected hostname/domain']);
-      var tbody = wrap.querySelector('tbody');
-      state.changes.forEach(function(c){ var tr = document.createElement('tr'); tr.innerHTML = '<td>'+escapeHtml(dateFmt(c.dateDetected))+'</td><td><strong>'+escapeHtml(c.vendor)+'</strong></td><td>'+escapeHtml(c.changeType)+'</td><td>'+escapeHtml(c.findingName)+'</td><td></td><td>'+escapeHtml(c.affectedAsset)+'</td>'; tr.children[4].appendChild(sev(c.severity)); tbody.appendChild(tr); });
-      if (!state.changes.length) tbody.appendChild(emptyRow(6, 'No 30-day risk changes are available yet.'));
-      content.appendChild(wrap);
-    }
-
-    function renderCampaigns() {
-      content.innerHTML = '<div class="section-title"><h2>Remediation Campaigns</h2><span class="muted">Common findings grouped into action plans.</span></div>';
-      var grid = el('div','grid campaigns');
-      state.campaigns.forEach(function(c){ var card = el('div','card campaign'); card.innerHTML = '<h3>'+escapeHtml(c.name)+'</h3><div><strong>Finding:</strong> '+escapeHtml(c.findingAddressed)+'</div><div><strong>Affected vendors:</strong> '+escapeHtml(c.affectedVendorCount)+'</div><div><strong>Status:</strong> '+escapeHtml(c.status)+' · <strong>Target:</strong> '+escapeHtml(c.targetTimeframe)+'</div><div><strong>Next action:</strong> '+escapeHtml(c.nextAction)+'</div>'; card.insertBefore(sev(c.severity), card.children[1]); grid.appendChild(card); });
-      content.appendChild(grid);
-    }
-
-    function renderReports() {
-      content.innerHTML = '<div class="section-title"><h2>Reports</h2><span class="muted">Every request is scoped to '+escapeHtml(PORTFOLIO_NAME)+'.</span></div>';
-      var reports = [ ['executive_summary_pdf','Executive Summary PDF'], ['board_summary_pdf','Board Summary PDF'], ['board_summary_pptx','Board Summary PPTX'], ['vendor_detailed_pdf','Vendor Detailed PDF'], ['vendor_risk_profile_xlsx','Vendor Risk Profile XLSX'], ['vendor_vulnerabilities_overview_xlsx','Vendor Vulnerabilities Overview XLSX'], ['vendor_domain_list_pdf','Vendor Domain List PDF'] ];
-      var grid = el('div','grid reports');
-      reports.forEach(function(r){ var card = el('div','card report'); card.innerHTML = '<h3>'+escapeHtml(r[1])+'</h3><p class="muted">Generate a '+escapeHtml(r[1])+' for '+escapeHtml(PORTFOLIO_NAME)+'.</p><button class="btn" data-type="'+escapeHtml(r[0])+'">Request report</button><div class="muted result"></div>'; grid.appendChild(card); });
-      grid.onclick = function(e){ if (!e.target.matches('button')) return; var card = e.target.closest('.report'); var result = card.querySelector('.result'); result.textContent = 'Queueing report…'; fetch('/api/reports/request', { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify({ type:e.target.dataset.type, portfolioName: PORTFOLIO_NAME }) }).then(function(res){ return res.json(); }).then(function(data){ result.innerHTML = 'Status: '+escapeHtml(data.status)+' · ID: '+escapeHtml(data.id || '—')+' · <a href="/api/reports/download?id='+encodeURIComponent(data.id || '')+'">download placeholder</a>'; }).catch(function(err){ result.textContent = 'Report request failed: ' + err.message; }); };
-      content.appendChild(grid);
-    }
-
-    function tableWrap(id, headers) { var wrap = el('div','table-wrap'); wrap.id = id; var table = document.createElement('table'); table.innerHTML = '<thead><tr>'+headers.map(function(h){ return '<th>'+escapeHtml(h)+'</th>'; }).join('')+'</tr></thead><tbody></tbody>'; wrap.appendChild(table); return wrap; }
-    function emptyRow(cols, message) { var tr = document.createElement('tr'); tr.innerHTML = '<td class="empty" colspan="'+cols+'">'+escapeHtml(message)+'</td>'; return tr; }
-
-    function sampleOverview(){ return { portfolioName:PORTFOLIO_NAME, averageScore:716, vendorCount:5, criticalRiskCount:3, highRiskCount:5, vendorsBelowThreshold:2, newlyIntroduced30d:4, remediated30d:2, topFindingName:'DMARC policy not enforced', topFindingAffectedVendorCount:3, topCampaignRecommendation:'Send a shared DMARC/SPF/DKIM remediation brief.', executiveSummary:'The '+PORTFOLIO_NAME+' portfolio currently has 5 monitored vendors with an average score of 716. There are 3 critical risks and 5 high risks across the portfolio. The most common issue is DMARC policy not enforced, affecting 3 vendors. Recommended next step: Send a shared DMARC/SPF/DKIM remediation brief.' }; }
-    function sampleRisks(){ return [ {name:'DMARC policy not enforced', severity:'high', category:'Email Security', type:'email', subtype:'authentication', vendorsImpacted:3, affectedHostnames:['payroll.acme.example','records.beacon.example','notify.civic.example'], firstDetected:'2026-04-12', recommendation:'Publish DMARC quarantine or reject policy after validating alignment.'}, {name:'Exposed remote administration service', severity:'critical', category:'Network Exposure', type:'service', subtype:'exposed-service', vendorsImpacted:1, affectedHostnames:['payroll.acme.example'], firstDetected:'2026-05-03', recommendation:'Restrict administrative ports to trusted networks immediately.'} ]; }
-    function sampleVendors(){ return [ {name:'Acme Payroll Services', domain:'payroll.acme.example', score:642, trend30d:-28, criticalRiskCount:2, highRiskCount:1, totalOpenRisks:3, lastUpdated:'2026-05-09T18:25:00Z', priority:'Critical'}, {name:'Harbor HR Platform', domain:'hr.harbor.example', score:705, trend30d:-17, criticalRiskCount:1, highRiskCount:1, totalOpenRisks:2, lastUpdated:'2026-05-07T14:45:00Z', priority:'Critical'} ]; }
-    function sampleChanges(){ return [ {dateDetected:'2026-05-09T12:10:00Z', vendor:'Acme Payroll Services', changeType:'new risk', findingName:'Outdated web server version detected', severity:'critical', affectedAsset:'payroll.acme.example'} ]; }
-    function sampleCampaigns(){ return [ {name:'DMARC/SPF/DKIM remediation', findingAddressed:'DMARC policy not enforced', severity:'high', affectedVendorCount:3, status:'In Progress', targetTimeframe:'30 days', nextAction:'Send a shared remediation brief and request target dates.'} ]; }
-
-    loadAll();
-  </script>
+  <header><div class="wrap"><div class="eyebrow">Portfolio Risk Profile API · TPRM Operations Center</div><h1>Portfolio Cyber Risk Intelligence</h1><p class="sub">A portfolio-wide UpGuard Vendor Risk console centered on common risks, remediation campaigns, 30-day movement, and executive reporting.</p><div class="portfolio-pill">Portfolio: <span>${PORTFOLIO_NAME}</span></div></div></header>
+  <main><div class="shell"><div class="statusbar"><div class="status" id="status">Loading portfolio intelligence…</div><div id="warning"></div></div><nav class="tabs" id="tabs"></nav><section class="content" id="content"><div class="loading">Loading portfolio risk profile…</div></section></div></main>
+  <div class="drawer" id="drawer"><div class="drawer-panel"><button class="close" id="closeDrawer">Close</button><div id="drawerContent"></div></div></div>
+<script>
+(function(){
+  var PORTFOLIO_NAME=${JSON.stringify(PORTFOLIO_NAME)};
+  var tabs=[['overview','Overview'],['risks','Common Risks'],['vendors','Vendors'],['changes','Changes'],['campaigns','Remediation Campaigns'],['reports','Reports']];
+  var active='overview';
+  var state={overview:null,risks:[],vendors:[],changes:[],campaigns:[],sort:{risks:'priority',vendors:'priority'}};
+  var content=document.getElementById('content'), status=document.getElementById('status'), warning=document.getElementById('warning'), drawer=document.getElementById('drawer'), drawerContent=document.getElementById('drawerContent');
+  document.getElementById('closeDrawer').onclick=function(){drawer.classList.remove('open')};
+  document.getElementById('tabs').innerHTML=tabs.map(function(t){return '<button class="tab" data-tab="'+t[0]+'">'+t[1]+'</button>'}).join('');
+  document.getElementById('tabs').onclick=function(e){if(!e.target.matches('.tab'))return;active=e.target.dataset.tab;render()};
+  function api(path){return fetch(path).then(function(res){if(!res.ok)throw new Error('HTTP '+res.status);return res.json()})}
+  function loadAll(){Promise.all([api('/api/portfolio/overview'),api('/api/portfolio/risk-profile'),api('/api/portfolio/vendors'),api('/api/portfolio/changes'),api('/api/portfolio/campaigns')]).then(function(r){state.overview=r[0];state.risks=r[1].risks||[];state.vendors=r[2].vendors||[];state.changes=r[3].changes||[];state.campaigns=r[4].campaigns||[];status.innerHTML='<strong>'+escapeHtml(PORTFOLIO_NAME)+'</strong> · Source: '+escapeHtml(r[1].source)+' · Generated '+fmtDate(r[0].generatedAt);var w=r.find(function(x){return x.warning});warning.innerHTML=w&&w.warning?'<div class="warning">'+escapeHtml(w.warning.message)+'</div>':'';render()}).catch(function(err){content.innerHTML='<div class="card"><h2>Unable to load dashboard</h2><p class="muted">'+escapeHtml(err.message)+'</p></div>';status.textContent='Error loading portfolio intelligence';});}
+  function render(){document.querySelectorAll('.tab').forEach(function(b){b.classList.toggle('active',b.dataset.tab===active)});({overview:renderOverview,risks:renderRisks,vendors:renderVendors,changes:renderChanges,campaigns:renderCampaigns,reports:renderReports}[active])();}
+  function renderOverview(){var o=state.overview||{};content.innerHTML='<div class="grid metrics">'+metric('Monitored vendors',o.totalVendors,'Portfolio population')+metric('Average score',o.averageScore==null?'—':o.averageScore,'From vendor score endpoint')+metric('Critical risks',o.criticalRiskCount,'Vendor-risk instances')+metric('High risks',o.highRiskCount,'Vendor-risk instances')+'</div><div class="grid two" style="margin-top:16px"><div class="card"><div class="section-title"><h2>Executive Summary</h2><span class="muted">Generated '+escapeHtml(fmtDate(o.generatedAt))+'</span></div><p class="summary">'+escapeHtml(o.executiveSummary||'No summary available.')+'</p></div><div class="card"><h2>Most Severe Portfolio Issue</h2><p><strong>'+escapeHtml(o.mostSevereIssue?o.mostSevereIssue.name:'None detected')+'</strong></p><div id="sevSlot"></div><p class="muted">Affected vendors: '+escapeHtml(o.mostSevereIssue?o.mostSevereIssue.vendorsImpacted:0)+' · Total affected vendor-risk instances: '+escapeHtml(o.totalAffectedVendors||0)+'</p><p class="muted">Vendors below threshold: '+escapeHtml(o.vendorsBelowThreshold||0)+'</p></div></div><div class="card" style="margin-top:16px"><div class="section-title"><h2>Top 5 Common Risks</h2><span class="muted">Sorted by severity and affected count</span></div><div id="topRisks"></div></div>';var slot=document.getElementById('sevSlot');if(slot&&o.mostSevereIssue)slot.appendChild(sev(o.mostSevereIssue.severity));var top=document.getElementById('topRisks');(o.topRisks||[]).forEach(function(r){var row=document.createElement('div');row.style='display:flex;justify-content:space-between;gap:12px;padding:10px 0;border-bottom:1px solid var(--line)';row.innerHTML='<span><strong>'+escapeHtml(r.name)+'</strong><br><span class="muted">'+escapeHtml(r.category)+' · '+escapeHtml(r.type)+'</span></span><span>'+escapeHtml(r.vendorsImpacted)+' vendors</span>';top.appendChild(row)});if(!(o.topRisks||[]).length)top.innerHTML='<div class="empty">No common risks available.</div>';}
+  function renderRisks(){content.innerHTML='<div class="section-title"><h2>Common Risks</h2><span class="muted">Portfolio Risk Profile intelligence</span></div><div class="filters"><input id="q" placeholder="Search findings, hostnames…"><select id="severity"><option value="">All severities</option><option>critical</option><option>high</option><option>medium</option><option>low</option><option>informational</option></select><select id="category"><option value="">All categories</option></select></div>';var cats=Array.from(new Set(state.risks.map(function(r){return r.category}).filter(Boolean))).sort();var cat=document.getElementById('category');cats.forEach(function(c){var o=document.createElement('option');o.textContent=c;cat.appendChild(o)});var wrap=tableWrap('risksTable',['Finding','Severity','Category','Type/Subtype','Affected Vendors','First Detected','Recommendation']);content.appendChild(wrap);function draw(){var q=document.getElementById('q').value.toLowerCase(),s=document.getElementById('severity').value,c=document.getElementById('category').value;var rows=state.risks.filter(function(r){return(!s||r.severity===s)&&(!c||r.category===c)&&(!q||JSON.stringify(r).toLowerCase().includes(q))}).slice().sort(function(a,b){return rank(b.severity)-rank(a.severity)||b.vendorsImpacted-a.vendorsImpacted});var tbody=wrap.querySelector('tbody');tbody.innerHTML='';rows.forEach(function(r){var tr=document.createElement('tr');tr.className='risk-row';tr.innerHTML='<td><strong>'+escapeHtml(r.name)+'</strong><div class="risk-detail"><div><strong>Affected hostnames/domains</strong></div><div class="chips">'+(r.affectedHostnames||[]).slice(0,30).map(function(h){return '<span class="chip">'+escapeHtml(h)+'</span>'}).join('')+'</div></div></td><td></td><td>'+escapeHtml(r.category)+'</td><td>'+escapeHtml(r.type)+'<br><span class="muted">'+escapeHtml(r.subtype)+'</span></td><td><strong>'+escapeHtml(r.vendorsImpacted)+'</strong></td><td>'+escapeHtml(fmtDate(r.firstDetected))+'</td><td>'+escapeHtml(r.recommendation)+'</td>';tr.children[1].appendChild(sev(r.severity));tr.onclick=function(){tr.classList.toggle('open')};tbody.appendChild(tr)});if(!rows.length)tbody.appendChild(emptyRow(7,'No risks match the current filters.'));}document.getElementById('q').oninput=draw;document.getElementById('severity').onchange=draw;cat.onchange=draw;draw();}
+  function renderVendors(){content.innerHTML='<div class="section-title"><h2>Vendors</h2><span class="muted">Operational remediation prioritization</span></div>';var wrap=tableWrap('vendorsTable',['Vendor / Domain','Score','Trend','Critical','High','Open Risks','Last Updated','Priority']);content.appendChild(wrap);var tbody=wrap.querySelector('tbody');state.vendors.forEach(function(v){var tr=document.createElement('tr');tr.innerHTML='<td><button class="btn" data-domain="'+escapeHtml(v.domain)+'">Details</button> <strong>'+escapeHtml(v.name)+'</strong><br><span class="muted">'+escapeHtml(v.domain)+'</span></td><td>'+escapeHtml(v.score==null?'—':v.score)+'</td><td class="'+(v.trend30d<0?'trend-neg':'trend-pos')+'">'+(v.trend30d>0?'+':'')+escapeHtml(v.trend30d||0)+'</td><td>'+escapeHtml(v.criticalRiskCount)+'</td><td>'+escapeHtml(v.highRiskCount)+'</td><td>'+escapeHtml(v.totalOpenRisks)+'</td><td>'+escapeHtml(fmtDate(v.lastUpdated))+'</td><td><span class="badge priority-'+escapeHtml(v.priority)+'">'+escapeHtml(v.priority)+'</span></td>';tbody.appendChild(tr)});if(!state.vendors.length)tbody.appendChild(emptyRow(8,'No vendors could be derived from the portfolio risk profile.'));wrap.onclick=function(e){if(!e.target.matches('button[data-domain]'))return;openVendor(e.target.dataset.domain);};}
+  function openVendor(domain){drawerContent.innerHTML='<h2>'+escapeHtml(domain)+'</h2><p class="muted">Loading vendor score detail…</p>';drawer.classList.add('open');api('/api/vendor/detail?hostname='+encodeURIComponent(domain)).then(function(v){drawerContent.innerHTML='<h2>'+escapeHtml(v.name||domain)+'</h2><p class="muted">'+escapeHtml(v.domain||domain)+' · Last updated '+escapeHtml(fmtDate(v.lastUpdated))+'</p><div class="grid metrics" style="grid-template-columns:repeat(2,1fr)">'+metric('Score',v.score==null?'—':v.score,'Current UpGuard vendor score')+metric('30-day trend',(v.trend30d>0?'+':'')+(v.trend30d||0),'Score movement')+'</div><h3>Category Scores</h3><pre>'+escapeHtml(JSON.stringify(v.categoryScores||{},null,2))+'</pre><h3>Active Findings</h3>'+((v.activeFindings||[]).map(function(r){return '<div class="card" style="margin:8px 0"><strong>'+escapeHtml(r.name)+'</strong><br>'+escapeHtml(r.recommendation||'')+'</div>'}).join('')||'<p class="muted">No active findings returned.</p>')+'<h3>Recent Changes</h3>'+((v.recentChanges||[]).map(function(c){return '<div>'+escapeHtml(fmtDate(c.dateDetected))+' · '+escapeHtml(c.changeType)+' · '+escapeHtml(c.findingName)+'</div>'}).join('')||'<p class="muted">No recent changes returned.</p>');}).catch(function(err){drawerContent.innerHTML='<h2>'+escapeHtml(domain)+'</h2><p class="warning">'+escapeHtml(err.message)+'</p>';});}
+  function renderChanges(){content.innerHTML='<div class="section-title"><h2>Changes</h2><span class="muted">30-day portfolio risk movement</span></div>';var wrap=tableWrap('changesTable',['Date','Vendor','Change Type','Finding','Severity','Affected Hostname']);var tbody=wrap.querySelector('tbody');state.changes.slice().sort(function(a,b){return new Date(b.dateDetected)-new Date(a.dateDetected)}).forEach(function(c){var tr=document.createElement('tr');tr.innerHTML='<td>'+escapeHtml(fmtDate(c.dateDetected))+'</td><td><strong>'+escapeHtml(c.vendor)+'</strong></td><td>'+escapeHtml(c.changeType)+'</td><td>'+escapeHtml(c.findingName||c.finding)+'</td><td></td><td>'+escapeHtml(c.affectedHostname||c.affectedAsset)+'</td>';tr.children[4].appendChild(sev(c.severity));tbody.appendChild(tr)});if(!state.changes.length)tbody.appendChild(emptyRow(6,'No 30-day risk changes are available yet.'));content.appendChild(wrap);}
+  function renderCampaigns(){content.innerHTML='<div class="section-title"><h2>Remediation Campaigns</h2><span class="muted">Common findings transformed into action plans</span></div>';var grid=el('div','grid campaigns');state.campaigns.forEach(function(c){var card=el('div','card campaign');card.innerHTML='<h3>'+escapeHtml(c.name)+'</h3><div class="sev"></div><p><strong>Associated finding:</strong> '+escapeHtml(c.associatedFinding||c.findingAddressed)+'</p><p><strong>Affected vendors:</strong> '+escapeHtml(c.affectedVendorCount)+'</p><p><strong>Status:</strong> '+escapeHtml(c.status)+' · <strong>Target:</strong> '+escapeHtml(c.targetTimeline||c.targetTimeframe)+'</p><p><strong>Recommended action:</strong> '+escapeHtml(c.recommendedAction||c.nextAction)+'</p>';card.querySelector('.sev').appendChild(sev(c.severity));grid.appendChild(card)});if(!state.campaigns.length)grid.innerHTML='<div class="empty card">No remediation campaigns generated yet.</div>';content.appendChild(grid);}
+  function renderReports(){content.innerHTML='<div class="section-title"><h2>Reports</h2><span class="muted">Executive and board reporting placeholders</span></div>';var reports=[['ExecutiveSummaryPDF','Executive Summary PDF'],['BoardSummaryPDF','Board Summary PDF'],['BoardSummaryPPTX','Board Summary PPTX'],['VendorSummaryPDF','Vendor Summary PDF'],['VendorDetailedPDF','Vendor Detail PDF'],['VendorRiskProfileXLSX','Risk Profile XLSX'],['VendorVulnsOverviewXLSX','Vulnerability Overview XLSX']];var grid=el('div','grid reports');reports.forEach(function(r){var card=el('div','card report');card.innerHTML='<h3>'+escapeHtml(r[1])+'</h3><p class="muted">Request '+escapeHtml(r[1])+' scoped to '+escapeHtml(PORTFOLIO_NAME)+'.</p><button class="btn" data-type="'+escapeHtml(r[0])+'">Request report</button><div class="muted result"></div>';grid.appendChild(card)});grid.onclick=function(e){if(!e.target.matches('button'))return;var card=e.target.closest('.report'),result=card.querySelector('.result');result.textContent='Queueing report…';fetch('/api/reports/request',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({type:e.target.dataset.type})}).then(function(res){return res.json()}).then(function(data){result.innerHTML='Status: '+escapeHtml(data.status)+' · ID: '+escapeHtml(data.id||'—')+' · <a href="/api/reports/download?id='+encodeURIComponent(data.id||'')+'">download placeholder</a>';}).catch(function(err){result.textContent='Report request failed: '+err.message;});};content.appendChild(grid);}
+  function metric(label,value,hint){return '<div class="card metric"><div class="label">'+escapeHtml(label)+'</div><div class="value">'+escapeHtml(value)+'</div><div class="hint">'+escapeHtml(hint)+'</div></div>'}
+  function tableWrap(id,headers){var wrap=el('div','table-wrap');wrap.id=id;var table=document.createElement('table');table.innerHTML='<thead><tr>'+headers.map(function(h){return '<th>'+escapeHtml(h)+'</th>'}).join('')+'</tr></thead><tbody></tbody>';wrap.appendChild(table);return wrap}
+  function emptyRow(cols,message){var tr=document.createElement('tr');tr.innerHTML='<td class="empty" colspan="'+cols+'">'+escapeHtml(message)+'</td>';return tr}
+  function sev(s){var span=el('span','badge '+(s||'medium'));span.textContent=s||'medium';return span}
+  function el(tag,cls){var e=document.createElement(tag);if(cls)e.className=cls;return e}
+  function rank(s){return {critical:4,high:3,medium:2,low:1,informational:0}[s]||0}
+  function fmtDate(v){if(!v)return '—';var d=new Date(v);return isNaN(d)?v:d.toLocaleString()}
+  function escapeHtml(v){return String(v==null?'':v).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
+  loadAll();
+})();
+</script>
 </body>
 </html>`;
   return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,17 +7,20 @@ compatibility_date = "2025-09-06"
 enabled = true
 
 # Optional: turn on Access gating for API routes (set to "1" to require Cf-Access)
+# Required secrets/vars for live UpGuard data:
+# - UPGUARD_API_KEY (set with `wrangler secret put UPGUARD_API_KEY`)
+# - UPGUARD_PORTFOLIO_ID (set below per environment)
 [vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"
+UPGUARD_PORTFOLIO_ID = ""
 
 [env.staging]
 # Keep same entry file; secrets are environment-specific
 [env.staging.vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"
+UPGUARD_PORTFOLIO_ID = ""
 
 [env.production]
 [env.production.vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_COMMONWEALTH_COMMON_VENDORS_PORTFOLIO_ID = "Commonwealth Common Vendors"
+UPGUARD_PORTFOLIO_ID = ""


### PR DESCRIPTION
### Motivation
- Replace the original scorecard-centric dashboard with a portfolio-first UpGuard Vendor Risk console driven by the Portfolio Risk Profile API to surface common risks, remediation campaigns, changes, and executive reporting. 
- Use the official UpGuard public API (`/api/public/risks/vendors/all`) as the primary data source with proper non-Bearer `Authorization` header handling. 
- Preserve Cloudflare Worker architecture and existing auth-secret handling while enabling future D1 persistence for snapshots and trend analysis. 
- Provide a modern, executive-friendly UI with tabs for Overview, Common Risks, Vendors, Changes, Remediation Campaigns, and Reports.

### Description
- Reworked Worker API surface to provide portfolio routes: `GET /api/portfolio/risk-profile`, `GET /api/portfolio/overview`, `GET /api/portfolio/vendors`, `GET /api/portfolio/changes`, and `GET /api/portfolio/campaigns`, plus vendor detail at `GET /api/vendor/detail` and report placeholders at `POST /api/reports/request`, `GET /api/reports/status`, `GET /api/reports/download`.
- Implemented primary UpGuard Portfolio Risk Profile paging against `GET https://cyber-risk.upguard.com/api/public/risks/vendors/all?portfolios=${UPGUARD_PORTFOLIO_ID}&page_size=2000` with automatic `next_page_token` handling and normalization/merging of pages into a stable `PortfolioRisk` model.
- Added vendor enrichment using `GET https://cyber-risk.upguard.com/api/public/vendor?hostname=...` and change tracking via `GET https://cyber-risk.upguard.com/api/public/risk/vendors/diff` (normalized to `RiskChangeEvent`), plus deterministic remediation campaign generation and remedial action recommendations; included `TODO` notes where D1 persistence should be introduced.
- Modernized frontend (single-file served by Worker) into a responsive tabbed TPRM console with severity/category filters, risk grouping/sorting, expandable details, vendor detail drawer, trend indicators, remediation campaign cards, and report request UI; updated styles for light/dark.
- Added environment variables and auth handling: `UPGUARD_API_KEY` (sent exactly as `Authorization: <key>`) and `UPGUARD_PORTFOLIO_ID`; updated `wrangler.toml` comments and removed portfolio-id hardcoding.
- Misc: migrated package to ESM (`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fff911a8508332a32ec42cfb024972)