### PR TITLE
Default UpGuard portfolio id to "Commonwealth Common Vendors"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 // Portfolio-first risk intelligence for the configured UpGuard Vendor Risk portfolio.
 
 const PORTFOLIO_NAME = "Commonwealth Common Vendors";
+const DEFAULT_PORTFOLIO_ID = PORTFOLIO_NAME;
 const PORTFOLIO_THRESHOLD = 700;
 const UPGUARD_BASE_URL = "https://cyber-risk.upguard.com/api/public";
 const PORTFOLIO_PAGE_SIZE = 2000;
@@ -73,7 +74,8 @@ export default {
 };
 
 function getConfiguredPortfolioId(env) {
-  return String((env || {}).UPGUARD_PORTFOLIO_ID || "").trim();
+  const configuredPortfolioId = String((env || {}).UPGUARD_PORTFOLIO_ID || "").trim();
+  return configuredPortfolioId || DEFAULT_PORTFOLIO_ID;
 }
 
 function hasUpGuardConfig(env) {
@@ -85,7 +87,7 @@ async function loadPortfolioRiskProfile(env) {
   const portfolioId = getConfiguredPortfolioId(env);
 
   if (!apiKey) return withSampleRiskProfileWarning(null, "missing_api_key", "UPGUARD_API_KEY is not configured; showing sample portfolio risk profile data.");
-  if (!portfolioId) return withSampleRiskProfileWarning(null, "missing_portfolio_id", "UPGUARD_PORTFOLIO_ID is not configured; showing sample portfolio risk profile data.");
+  if (!portfolioId) return withSampleRiskProfileWarning(null, "missing_portfolio_id", "No portfolio ID is configured; showing sample portfolio risk profile data.");
 
   try {
     const pages = await fetchPortfolioRiskProfilePages(env, portfolioId);
@@ -538,7 +540,7 @@ function withSampleRiskProfileWarning(portfolioId, code, message) {
 
 function missingConfigWarning(env) {
   if (!String((env || {}).UPGUARD_API_KEY || "").trim()) return { code: "missing_api_key", message: "UPGUARD_API_KEY is not configured; showing sample data." };
-  return { code: "missing_portfolio_id", message: "UPGUARD_PORTFOLIO_ID is not configured; showing sample data." };
+  return { code: "missing_portfolio_id", message: "No portfolio ID is configured; showing sample data." };
 }
 
 function normalizeSampleVendorSummaries() {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,15 +12,15 @@ enabled = true
 # - UPGUARD_PORTFOLIO_ID (set below per environment)
 [vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_PORTFOLIO_ID = ""
+UPGUARD_PORTFOLIO_ID = "Commonwealth Common Vendors"
 
 [env.staging]
 # Keep same entry file; secrets are environment-specific
 [env.staging.vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_PORTFOLIO_ID = ""
+UPGUARD_PORTFOLIO_ID = "Commonwealth Common Vendors"
 
 [env.production]
 [env.production.vars]
 REQUIRE_ACCESS = "0"
-UPGUARD_PORTFOLIO_ID = ""
+UPGUARD_PORTFOLIO_ID = "Commonwealth Common Vendors"


### PR DESCRIPTION
### Motivation
- Ensure the application sends the requested portfolio identifier when no environment override is provided so UpGuard API calls include the expected portfolio.
- Avoid user-facing errors about a missing portfolio id by falling back to the known portfolio name.
- Make local and deployed environments explicit about the intended default portfolio.

### Description
- Added `DEFAULT_PORTFOLIO_ID` and updated `getConfiguredPortfolioId(env)` in `src/index.js` to return the configured `UPGUARD_PORTFOLIO_ID` or fall back to `DEFAULT_PORTFOLIO_ID`.
- Updated user-facing messages to use a clearer fallback wording when no portfolio id is configured.
- Updated `wrangler.toml` to set `UPGUARD_PORTFOLIO_ID = "Commonwealth Common Vendors"` for default, staging, and production vars so the env var is populated by default.
- All UpGuard API requests that use the resolved portfolio id continue to use the returned value so query params include `portfolios=Commonwealth+Common+Vendors` when not overridden.

### Testing
- Ran `node --check src/index.js` which completed without syntax errors.
- Ran a stubbed `node --input-type=module` test that stubs `fetch` and exercised the `/api/portfolio/risk-profile` code path, and verified the UpGuard request URL contains `portfolios=Commonwealth+Common+Vendors`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fffcf6e2248332b55865d3171b8f18)