### PR TITLE
Encode UpGuard query spaces as %20

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,10 @@ const REPORT_TYPES = {
 
 const SAMPLE_PORTFOLIO = createSamplePortfolio();
 
+function strictQueryString(params) {
+  return new URLSearchParams(params).toString().replace(/\+/g, "%20");
+}
+
 export default {
   async fetch(req, env) {
     const url = new URL(req.url);
@@ -105,9 +109,9 @@ async function fetchPortfolioRiskProfilePages(env, portfolioId) {
   const seenTokens = new Set();
 
   do {
-    const params = new URLSearchParams({ portfolios: portfolioId, page_size: String(PORTFOLIO_PAGE_SIZE) });
-    if (pageToken) params.set("page_token", pageToken);
-    const page = await fetchUpGuardJson(env, "/risks/vendors/all?" + params.toString());
+    const params = { portfolios: portfolioId, page_size: String(PORTFOLIO_PAGE_SIZE) };
+    if (pageToken) params.page_token = pageToken;
+    const page = await fetchUpGuardJson(env, "/risks/vendors/all?" + strictQueryString(params));
     pages.push(page);
     pageToken = String(page.next_page_token || page.nextPageToken || page.pagination?.next_page_token || "");
     if (pageToken && seenTokens.has(pageToken)) throw new Error("UpGuard risk-profile pagination returned a repeated next_page_token.");
@@ -137,8 +141,8 @@ async function loadPortfolioChanges(env, days) {
   }
 
   try {
-    const params = new URLSearchParams({ portfolios: getConfiguredPortfolioId(env), days: String(days) });
-    const data = await fetchUpGuardJson(env, "/risk/vendors/diff?" + params.toString());
+    const params = { portfolios: getConfiguredPortfolioId(env), days: String(days) };
+    const data = await fetchUpGuardJson(env, "/risk/vendors/diff?" + strictQueryString(params));
     const changes = extractItems(data, ["changes", "events", "results", "data", "diffs"]).map(normalizeChangeRecord).sort(sortNewestChangeFirst);
     // TODO(D1): persist diff events and derived snapshots for trend analysis and resolved-risk reporting.
     return { portfolioName: PORTFOLIO_NAME, portfolioId: getConfiguredPortfolioId(env), source: "upguard", warning: null, days, changes, generatedAt: new Date().toISOString() };


### PR DESCRIPTION
### Motivation
- UpGuard API calls were receiving spaces encoded as `+` which produced 404s for portfolio names with spaces, so query parameters must use percent-encoding (`%20`).

### Description
- Added a `strictQueryString` helper in `src/index.js` that builds a query string and replaces `+` with `%20` to ensure spaces are percent-encoded.
- Replaced `URLSearchParams(...).toString()` usage for UpGuard calls in `fetchPortfolioRiskProfilePages` and `loadPortfolioChanges` with `strictQueryString` so requests to `/risks/vendors/all` and `/risk/vendors/diff` send `Commonwealth%20Common%20Vendors` instead of `Commonwealth+Common+Vendors`.
- All changes are contained in `src/index.js` and preserve existing request/response handling via `fetchUpGuardJson`.

### Testing
- Ran `node --check src/index.js` to validate syntax and it succeeded.
- Verified query-string output with `node -e 'const qs = new URLSearchParams({portfolios:"Commonwealth Common Vendors", days:"30"}).toString().replace(/\+/g, "%20"); ...'` and it produced `portfolios=Commonwealth%20Common%20Vendors&days=30`.
- Ran `git diff --check` to ensure no whitespace or diff issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fffe9a7fb4833295c4560d81c77e9c)