### PR TITLE
Use UpGuard portfolio risk page size of 100

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const PORTFOLIO_NAME = "Commonwealth Common Vendors";
 const DEFAULT_PORTFOLIO_ID = PORTFOLIO_NAME;
 const PORTFOLIO_THRESHOLD = 700;
 const UPGUARD_BASE_URL = "https://cyber-risk.upguard.com/api/public";
-const PORTFOLIO_PAGE_SIZE = 2000;
+const PORTFOLIO_PAGE_SIZE = 100;
 
 /**
  * Stable frontend models emitted by the API routes:


### PR DESCRIPTION
### Motivation
- Align the Worker’s portfolio risk fetches with the documented/example UpGuard request pattern (`/risks/vendors/all?portfolios=...&page_size=100`) and avoid emitting an excessively large `page_size`.

### Description
- Change `PORTFOLIO_PAGE_SIZE` from `2000` to `100` so `fetchPortfolioRiskProfilePages` will request `page_size=100` while preserving the existing pagination handling.

### Testing
- Verified syntax with `node --check src/index.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffffa36f008332923e545002260cfd)