### PR TITLE
Use portfolio risk endpoint for changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,14 +140,15 @@ async function loadPortfolioChanges(env, days) {
     return { portfolioName: PORTFOLIO_NAME, source: "sample", warning: missingConfigWarning(env), days, changes: sampleChanges(days), generatedAt: new Date().toISOString() };
   }
 
+  const portfolioId = getConfiguredPortfolioId(env);
+
   try {
-    const params = { portfolios: getConfiguredPortfolioId(env), days: String(days) };
-    const data = await fetchUpGuardJson(env, "/risk/vendors/diff?" + strictQueryString(params));
-    const changes = extractItems(data, ["changes", "events", "results", "data", "diffs"]).map(normalizeChangeRecord).sort(sortNewestChangeFirst);
-    // TODO(D1): persist diff events and derived snapshots for trend analysis and resolved-risk reporting.
-    return { portfolioName: PORTFOLIO_NAME, portfolioId: getConfiguredPortfolioId(env), source: "upguard", warning: null, days, changes, generatedAt: new Date().toISOString() };
+    const pages = await fetchPortfolioRiskProfilePages(env, portfolioId);
+    const changes = riskProfilePagesToChangeRecords(pages, days).sort(sortNewestChangeFirst);
+    // TODO(D1): persist risk-profile snapshots here for true longitudinal portfolio change reporting.
+    return { portfolioName: PORTFOLIO_NAME, portfolioId, source: "upguard", warning: null, days, changes, generatedAt: new Date().toISOString() };
   } catch (e) {
-    return { portfolioName: PORTFOLIO_NAME, portfolioId: getConfiguredPortfolioId(env), source: "sample", warning: { code: "upguard_diff_unavailable", message: (e && e.message ? e.message : String(e)) + "; showing sample change events." }, days, changes: sampleChanges(days), generatedAt: new Date().toISOString() };
+    return { portfolioName: PORTFOLIO_NAME, portfolioId, source: "sample", warning: { code: "upguard_risk_profile_changes_unavailable", message: (e && e.message ? e.message : String(e)) + "; showing sample change events." }, days, changes: sampleChanges(days), generatedAt: new Date().toISOString() };
   }
 }
 
@@ -403,6 +404,30 @@ function normalizeChangeRecord(change) {
     affectedHostname: change.hostname || change.domain || change.asset || change.affected_hostname || "—",
     affectedAsset: change.hostname || change.domain || change.asset || change.affected_hostname || "—",
   };
+}
+
+function riskProfilePagesToChangeRecords(pages, days) {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return (pages || [])
+    .flatMap((page) => extractItems(page, ["risks", "findings", "grouped_risks", "common_risks", "results", "data"]))
+    .map(normalizePortfolioRisk)
+    .flatMap((risk) => {
+      const detectedAt = risk.firstDetected || new Date().toISOString();
+      if (risk.firstDetected && new Date(detectedAt) < cutoff) return [];
+      const affectedHostnames = risk.affectedHostnames.length ? risk.affectedHostnames : ["—"];
+      return affectedHostnames.map((hostname) => ({
+        id: [risk.id, hostname, detectedAt].join(":"),
+        date: detectedAt,
+        dateDetected: detectedAt,
+        vendor: hostname,
+        changeType: "New Risk",
+        finding: risk.name,
+        findingName: risk.name,
+        severity: risk.severity,
+        affectedHostname: hostname,
+        affectedAsset: hostname,
+      }));
+    });
 }
 
 function normalizeRemediationCampaigns(risks) {


### PR DESCRIPTION
### Motivation
- Replace the deprecated/undesired `/risk/vendors/diff` usage with the paginated portfolio risk profile endpoint to consistently source portfolio data from the same API.
- Derive the 30-day change records from the portfolio risk pages so the dashboard can show change events when the diff endpoint is unavailable.

### Description
- Updated `src/index.js` to have `loadPortfolioChanges` call `fetchPortfolioRiskProfilePages(env, portfolioId)` and use a new `riskProfilePagesToChangeRecords(pages, days)` helper to convert risk pages into change records instead of calling `"/risk/vendors/diff"`.
- Added `riskProfilePagesToChangeRecords` which normalizes risks, filters by the `days` cutoff, and emits dashboard-compatible change objects (fields like `id`, `dateDetected`, `vendor`, `changeType`, `finding`, `severity`, `affectedHostname`).
- Introduced a local `portfolioId` variable in `loadPortfolioChanges` and updated the error fallback to use the code `upguard_risk_profile_changes_unavailable` and return sample changes on failure.
- All code changes are contained in `src/index.js` and preserve existing UI models and sorting (`sortNewestChangeFirst`).

### Testing
- Ran `node --check src/index.js` to verify syntax and it succeeded.
- Performed a dry-run deploy with `npx wrangler deploy --dry-run` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0000f10a848332af2836c6c6996d68)