### PR TITLE
Fix dashboard partial loading; add debug routes and D1 schema checks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,13 @@ const PORTFOLIO_VENDORS = [
 const UPGUARD_DOMAIN_ENDPOINT = "https://cyber-risk.upguard.com/api/public/vendor/domain";
 const DEFAULT_BATCH_SIZE = 6;
 const MAX_BATCH_SIZE = 10;
+const REQUIRED_D1_TABLES = [
+  "vendors",
+  "check_results",
+  "waived_check_results",
+  "ingestion_runs",
+  "ingestion_errors",
+];
 
 export default {
   async fetch(request, env) {
@@ -101,6 +108,9 @@ export default {
         assertDb(env);
         return json({ ok: true, portfolioName: PORTFOLIO_NAME, vendorCount: PORTFOLIO_VENDORS.length, generatedAt: new Date().toISOString() });
       }
+
+      if (request.method === "GET" && url.pathname === "/api/debug/db") return json(await getDebugDb(env));
+      if (request.method === "GET" && url.pathname === "/api/debug/config") return json(getDebugConfig(env));
 
       if (request.method === "POST" && url.pathname === "/api/ingest") {
         const result = await runIngestion(env, { trigger: "api" });
@@ -117,6 +127,7 @@ export default {
       if (request.method === "GET" && url.pathname === "/api/dashboard/severity-breakdown") return json(await getSeverityBreakdown(env));
       if (request.method === "GET" && url.pathname === "/api/dashboard/categories") return json(await getCategories(env));
     } catch (error) {
+      if (error instanceof SchemaNotInitializedError) return json(error.toResponseBody(), 503);
       return json({ error: "worker_error", message: getErrorMessage(error) }, 500);
     }
 
@@ -308,6 +319,7 @@ async function logIngestionError(db, failure) {
 
 async function listVendors(env) {
   assertDb(env);
+  await assertD1Schema(env);
   const { results } = await env.DB.prepare(
     `SELECT
        v.hostname,
@@ -326,6 +338,7 @@ async function listVendors(env) {
 
 async function getVendorDetail(env, hostname) {
   assertDb(env);
+  await assertD1Schema(env);
   const cleanHostname = String(hostname || "").trim().toLowerCase();
   if (!cleanHostname) return { error: "missing_hostname", message: "Provide a hostname." };
 
@@ -345,6 +358,7 @@ async function getVendorDetail(env, hostname) {
 
 async function getDashboardOverview(env) {
   assertDb(env);
+  await assertD1Schema(env);
   const totals = await env.DB.prepare(
     `SELECT COUNT(*) AS total_vendors, ROUND(AVG(automated_score), 2) AS average_score FROM vendors`
   ).first();
@@ -384,6 +398,7 @@ async function getDashboardOverview(env) {
 
 async function getCommonRisks(env) {
   assertDb(env);
+  await assertD1Schema(env);
   const { results } = await env.DB.prepare(
     `SELECT
        title,
@@ -401,6 +416,7 @@ async function getCommonRisks(env) {
 
 async function getSeverityBreakdown(env) {
   assertDb(env);
+  await assertD1Schema(env);
   const { results } = await env.DB.prepare(
     `SELECT COALESCE(severity_name, 'Unknown') AS severity_name, COUNT(*) AS count
      FROM check_results
@@ -413,6 +429,7 @@ async function getSeverityBreakdown(env) {
 
 async function getCategories(env) {
   assertDb(env);
+  await assertD1Schema(env);
   const { results } = await env.DB.prepare(
     `SELECT COALESCE(category, 'Uncategorized') AS category, COUNT(*) AS count
      FROM check_results
@@ -440,6 +457,89 @@ function hydrateCheck(check) {
     sources: parseJson(check.sources_json, []),
     raw: parseJson(check.raw_json, {}),
   };
+}
+
+
+async function getDebugDb(env) {
+  const hasDb = Boolean(env.DB);
+  if (!hasDb) {
+    return {
+      hasDb,
+      expectedBinding: "DB",
+      databaseBindingNameExpected: "DB",
+      tables: {},
+      missingTables: [...REQUIRED_D1_TABLES],
+    };
+  }
+
+  const tables = {};
+  const missingTables = [];
+
+  for (const tableName of REQUIRED_D1_TABLES) {
+    const exists = await d1TableExists(env.DB, tableName);
+    if (!exists) {
+      missingTables.push(tableName);
+      tables[tableName] = { exists: false, rowCount: null };
+      continue;
+    }
+
+    const row = await env.DB.prepare(`SELECT COUNT(*) AS row_count FROM ${tableName}`).first();
+    tables[tableName] = { exists: true, rowCount: row?.row_count || 0 };
+  }
+
+  return {
+    hasDb,
+    expectedBinding: "DB",
+    databaseBindingNameExpected: "DB",
+    tables,
+    missingTables,
+  };
+}
+
+function getDebugConfig(env) {
+  return {
+    hasDb: Boolean(env.DB),
+    hasUpGuardApiKey: Boolean(String(env.UPGUARD_API_KEY || "").trim()),
+    portfolioName: PORTFOLIO_NAME,
+    configuredVendorCount: PORTFOLIO_VENDORS.length,
+    databaseBindingNameExpected: "DB",
+  };
+}
+
+async function assertD1Schema(env, tableNames = REQUIRED_D1_TABLES) {
+  const missingTables = await getMissingD1Tables(env.DB, tableNames);
+  if (missingTables.length > 0) throw new SchemaNotInitializedError(missingTables);
+}
+
+async function getMissingD1Tables(db, tableNames) {
+  const missingTables = [];
+  for (const tableName of tableNames) {
+    if (!(await d1TableExists(db, tableName))) missingTables.push(tableName);
+  }
+  return missingTables;
+}
+
+async function d1TableExists(db, tableName) {
+  const row = await db.prepare(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?"
+  ).bind(tableName).first();
+  return Boolean(row?.name);
+}
+
+class SchemaNotInitializedError extends Error {
+  constructor(missingTables) {
+    super("D1 tables are missing. Run the migrations before loading dashboard data.");
+    this.name = "SchemaNotInitializedError";
+    this.missingTables = missingTables;
+  }
+
+  toResponseBody() {
+    return {
+      error: "schema_not_initialized",
+      message: this.message,
+      missingTables: this.missingTables,
+    };
+  }
 }
 
 function assertDb(env) {
@@ -535,6 +635,8 @@ function renderDashboardShell() {
     button:hover, .tab.active { background: #2f6fed; color: white; }
     .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; }
     .card { background: rgba(15, 23, 42, .82); border: 1px solid rgba(148,163,184,.18); border-radius: 22px; padding: 20px; box-shadow: 0 20px 60px rgba(0,0,0,.25); }
+    .error-card { border-color: rgba(248,113,113,.55); background: rgba(127, 29, 29, .35); }
+    .error-card h2 { color: #fecaca; }
     .metric { font-size: 34px; font-weight: 800; margin: 6px 0; }
     table { width: 100%; border-collapse: collapse; overflow: hidden; }
     th, td { padding: 12px 10px; text-align: left; border-bottom: 1px solid rgba(148,163,184,.14); vertical-align: top; }
@@ -570,57 +672,108 @@ function renderDashboardShell() {
     <section id="vendor-detail" class="view hidden"></section>
   </main>
 <script>
-const state = { overview: null, vendors: [], risks: [], severities: [], categories: [] };
+const state = { overview: null, vendors: [], risks: [], severities: [], categories: [], errors: {} };
 const $ = (id) => document.getElementById(id);
 const esc = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
+const jsString = (value) => JSON.stringify(String(value ?? ''));
 const badge = (name) => '<span class="badge ' + esc(String(name || '').toLowerCase()) + '">' + esc(name || 'Unknown') + '</span>';
-async function api(path, options) {
-  const response = await fetch(path, options);
-  const data = await response.json();
-  if (!response.ok && response.status !== 207) throw new Error(data.message || data.error || 'Request failed');
+const API_TIMEOUT_MS = 20000;
+async function api(path, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  let response;
+  let data = null;
+  let text = '';
+
+  try {
+    response = await fetch(path, { ...options, signal: controller.signal });
+    text = await response.text();
+    data = parseApiResponseBody(text);
+  } catch (error) {
+    if (error.name === 'AbortError') throw new Error(path + ' timed out after ' + Math.round(API_TIMEOUT_MS / 1000) + ' seconds');
+    throw new Error(path + ' failed: ' + (error.message || String(error)));
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok && response.status !== 207) {
+    throw new Error(formatApiError(path, response.status, data, text));
+  }
+
   return data;
 }
+function parseApiResponseBody(text) {
+  if (!text) return null;
+  try { return JSON.parse(text); } catch (_error) { return text; }
+}
+function formatApiError(path, status, data, text) {
+  const bodyMessage = data && typeof data === 'object' ? (data.message || data.error) : text;
+  return path + ' failed with HTTP ' + status + (bodyMessage ? ': ' + bodyMessage : '');
+}
 async function load() {
-  try {
-    const [overview, vendors, risks, severities, categories] = await Promise.all([
-      api('/api/dashboard/overview'), api('/api/vendors'), api('/api/dashboard/common-risks'), api('/api/dashboard/severity-breakdown'), api('/api/dashboard/categories')
-    ]);
-    state.overview = overview; state.vendors = vendors.vendors || []; state.risks = risks.risks || []; state.severities = severities.severities || []; state.categories = categories.categories || [];
-    $('status').innerHTML = 'Loaded ' + state.vendors.length + ' vendors. Data model is trend-ready for future snapshots and remediation tracking.';
-    renderOverview(); renderVendors(); renderRisks(); renderSeverity();
-  } catch (error) {
-    $('status').innerHTML = 'Dashboard needs D1 schema and data. Run migrations, configure DB and UPGUARD_API_KEY, then POST /api/ingest. Error: ' + esc(error.message);
-  }
+  $('status').innerHTML = 'Loading dashboard data…';
+  state.errors = {};
+
+  const endpoints = [
+    { key: 'overview', label: 'Dashboard overview', path: '/api/dashboard/overview', apply: (data) => { state.overview = data; } },
+    { key: 'vendors', label: 'Vendors', path: '/api/vendors', apply: (data) => { state.vendors = data.vendors || []; } },
+    { key: 'risks', label: 'Common risks', path: '/api/dashboard/common-risks', apply: (data) => { state.risks = data.risks || []; } },
+    { key: 'severities', label: 'Severity breakdown', path: '/api/dashboard/severity-breakdown', apply: (data) => { state.severities = data.severities || []; } },
+    { key: 'categories', label: 'Categories', path: '/api/dashboard/categories', apply: (data) => { state.categories = data.categories || []; } },
+  ];
+
+  const results = await Promise.allSettled(endpoints.map((endpoint) => api(endpoint.path)));
+  let successCount = 0;
+
+  results.forEach((result, index) => {
+    const endpoint = endpoints[index];
+    if (result.status === 'fulfilled') {
+      successCount += 1;
+      endpoint.apply(result.value || {});
+    } else {
+      state.errors[endpoint.key] = { ...endpoint, message: result.reason?.message || String(result.reason) };
+    }
+  });
+
+  const failureCount = endpoints.length - successCount;
+  $('status').innerHTML = successCount + ' of ' + endpoints.length + ' dashboard endpoints loaded. ' +
+    (failureCount ? 'Review the error cards below; loaded sections remain available.' : 'Loaded ' + state.vendors.length + ' vendors. Data model is trend-ready for future snapshots and remediation tracking.');
+  renderOverview(); renderVendors(); renderRisks(); renderSeverity();
 }
 function renderOverview() {
   const o = state.overview || {};
-  $('overview').innerHTML = '<div class="grid">' +
+  $('overview').innerHTML = errorCard('overview') + '<div class="grid">' +
     metric('Total vendors', o.totalVendors) + metric('Average score', o.averageScore ?? '—') + metric('Critical findings', o.criticalFindingCount) + metric('High findings', o.highFindingCount) +
     '</div><div class="split"><div class="card"><h2>Most common categories</h2>' + list(o.mostCommonCategories, 'category') + '</div><div class="card"><h2>Most common risk types</h2>' + list(o.mostCommonRiskTypes, 'risk_type') + '</div></div>';
 }
 function renderVendors() {
-  $('vendors').innerHTML = '<div class="card"><h2>Vendor Table</h2><table><thead><tr><th>Hostname</th><th>Score</th><th>Scanned</th><th>Total checks</th><th>Failed</th><th>Waived</th></tr></thead><tbody>' +
-    state.vendors.map(v => '<tr><td><span class="link" onclick="showVendor(\'' + esc(v.hostname) + '\')">' + esc(v.hostname) + '</span></td><td>' + esc(v.score ?? '—') + '</td><td>' + esc(v.scanned_at || '—') + '</td><td>' + esc(v.total_checks) + '</td><td>' + esc(v.failed_checks) + '</td><td>' + esc(v.waived_checks) + '</td></tr>').join('') +
+  $('vendors').innerHTML = errorCard('vendors') + '<div class="card"><h2>Vendor Table</h2><table><thead><tr><th>Hostname</th><th>Score</th><th>Scanned</th><th>Total checks</th><th>Failed</th><th>Waived</th></tr></thead><tbody>' +
+    state.vendors.map(v => '<tr><td><span class="link" onclick="showVendor(' + esc(jsString(v.hostname)) + ')">' + esc(v.hostname) + '</span></td><td>' + esc(v.score ?? '—') + '</td><td>' + esc(v.scanned_at || '—') + '</td><td>' + esc(v.total_checks) + '</td><td>' + esc(v.failed_checks) + '</td><td>' + esc(v.waived_checks) + '</td></tr>').join('') +
     '</tbody></table></div>';
 }
 function renderRisks() {
-  $('common-risks').innerHTML = '<div class="card"><h2>Common Risks</h2><table><thead><tr><th>Risk</th><th>Category</th><th>Severity</th><th>Affected vendors</th></tr></thead><tbody>' +
+  $('common-risks').innerHTML = errorCard('risks') + '<div class="card"><h2>Common Risks</h2><table><thead><tr><th>Risk</th><th>Category</th><th>Severity</th><th>Affected vendors</th></tr></thead><tbody>' +
     state.risks.map(r => '<tr><td>' + esc(r.title || 'Untitled') + '</td><td>' + esc(r.category || 'Uncategorized') + '</td><td>' + badge(r.severity_name || r.severity) + '</td><td>' + esc(r.affected_vendor_count) + '</td></tr>').join('') +
     '</tbody></table></div>';
 }
 function renderSeverity() {
-  $('severity').innerHTML = '<div class="split"><div class="card"><h2>Severity Breakdown</h2>' + list(state.severities, 'severity_name') + '</div><div class="card"><h2>Category Grouping</h2>' + list(state.categories, 'category') + '</div></div>';
+  $('severity').innerHTML = errorCard('severities') + errorCard('categories') + '<div class="split"><div class="card"><h2>Severity Breakdown</h2>' + list(state.severities, 'severity_name') + '</div><div class="card"><h2>Category Grouping</h2>' + list(state.categories, 'category') + '</div></div>';
 }
 async function showVendor(hostname) {
   show('vendor-detail');
   $('vendor-detail').innerHTML = '<div class="card">Loading ' + esc(hostname) + '…</div>';
-  const data = await api('/api/vendor/' + encodeURIComponent(hostname));
-  $('vendor-detail').innerHTML = '<div class="card"><h2>' + esc(hostname) + '</h2><p>Score: <strong>' + esc(data.vendor.automated_score ?? '—') + '</strong> · Scanned: ' + esc(data.vendor.scanned_at || '—') + '</p></div>' +
-    '<div class="split"><div class="card"><h2>Active Checks</h2>' + checkTable(data.checkResults || []) + '</div><div class="card"><h2>Waived Checks</h2>' + checkTable(data.waivedCheckResults || []) + '</div></div>';
+  try {
+    const data = await api('/api/vendor/' + encodeURIComponent(hostname));
+    $('vendor-detail').innerHTML = '<div class="card"><h2>' + esc(hostname) + '</h2><p>Score: <strong>' + esc(data.vendor.automated_score ?? '—') + '</strong> · Scanned: ' + esc(data.vendor.scanned_at || '—') + '</p></div>' +
+      '<div class="split"><div class="card"><h2>Active Checks</h2>' + checkTable(data.checkResults || []) + '</div><div class="card"><h2>Waived Checks</h2>' + checkTable(data.waivedCheckResults || []) + '</div></div>';
+  } catch (error) {
+    $('vendor-detail').innerHTML = '<div class="card error-card"><h2>Vendor failed to load</h2><p>' + esc(error.message) + '</p></div>';
+  }
 }
 function checkTable(rows) { return '<table><thead><tr><th>Title</th><th>Category</th><th>Severity</th><th>Passed</th></tr></thead><tbody>' + rows.map(c => '<tr><td>' + esc(c.title || c.check_id || 'Untitled') + '</td><td>' + esc(c.category || 'Uncategorized') + '</td><td>' + badge(c.severity_name || c.severity) + '</td><td>' + (c.passed ? 'Yes' : 'No') + '</td></tr>').join('') + '</tbody></table>'; }
 function metric(label, value) { return '<div class="card"><div class="muted">' + esc(label) + '</div><div class="metric">' + esc(value ?? 0) + '</div></div>'; }
 function list(rows, key) { return '<table><tbody>' + (rows || []).map(row => '<tr><td>' + esc(row[key] || 'Unknown') + '</td><td>' + esc(row.count) + '</td></tr>').join('') + '</tbody></table>'; }
+function errorCard(key) { const error = state.errors[key]; return error ? '<div class="card error-card"><h2>' + esc(error.label) + ' failed to load</h2><p>' + esc(error.message) + '</p></div>' : ''; }
 function show(view) { document.querySelectorAll('.view').forEach(el => el.classList.add('hidden')); $(view).classList.remove('hidden'); document.querySelectorAll('[data-view]').forEach(btn => btn.classList.toggle('active', btn.dataset.view === view)); }
 document.querySelectorAll('[data-view]').forEach(btn => btn.addEventListener('click', () => show(btn.dataset.view)));
 $('ingest').addEventListener('click', async () => { $('status').innerHTML = 'Ingestion running…'; try { const result = await api('/api/ingest', { method: 'POST' }); $('status').innerHTML = '<pre>' + esc(JSON.stringify(result, null, 2)) + '</pre>'; await load(); } catch (e) { $('status').innerHTML = esc(e.message); } });


### PR DESCRIPTION
### Motivation
- The dashboard used `Promise.all()` to load multiple endpoints causing the whole UI to stay stuck on “Loading dashboard data…” if any single request hung or failed.  
- The frontend needed timeout protection and clearer endpoint-aware errors so partial data can render and operators can diagnose failures.  
- Backend dashboard endpoints should return a friendly JSON error when required D1 tables are missing and provide debug endpoints to inspect DB and config status without exposing secrets.

### Description
- Switched frontend loading to `Promise.allSettled()` and applied individual results to state so successfully-loaded sections render even when some endpoints fail.  
- Added a 20-second request timeout using `AbortController` in the frontend `api()` helper (`API_TIMEOUT_MS = 20000`) and improved error text to include endpoint path, HTTP status, and response body/message when available.  
- Surface per-endpoint errors in the UI via `state.errors` and visual error cards for failed sections while keeping other sections usable and updating the `#status` area regardless of failures.  
- Fixed vendor link escaping when embedding hostnames into inline `onclick` by serializing with `JSON.stringify` to avoid broken HTML/JS.  
- Added server-side support: `REQUIRED_D1_TABLES` metadata, `assertD1Schema()`/`getMissingD1Tables()`/`d1TableExists()`, and `SchemaNotInitializedError` which returns a friendly `schema_not_initialized` JSON payload with `missingTables` (returned as HTTP `503`).  
- Added two diagnostic routes: `GET /api/debug/db` (checks DB binding, table existence and row counts, lists missing tables) and `GET /api/debug/config` (returns `hasDb`, `hasUpGuardApiKey`, `portfolioName`, `configuredVendorCount`, and the expected binding name `DB`), ensuring the API key itself is never exposed.  
- Updated dashboard-related backend routes (`/api/vendors`, `/api/vendor/:host`, `/api/dashboard/*`) to call `assertD1Schema()` so they return the friendly schema error instead of an opaque worker error when tables are missing.

### Testing
- Ran `node --check src/index.js` to validate syntax; it succeeded.  
- Executed a Node-based validation that loaded the dashboard HTML, evaluated the embedded frontend script, and queried `GET /api/debug/config` and `GET /api/debug/db` against the worker to validate the debug routes; this validation passed.  
- Simulated a missing-table scenario with a fake `DB.prepare` and verified `GET /api/dashboard/overview` returns HTTP `503` with the `schema_not_initialized` JSON and `missingTables`; this test passed.  
- Performed `npx wrangler deploy --dry-run` to ensure Wrangler packaging and bindings are intact; this succeeded.  
- Attempted a UI screenshot with `npx playwright screenshot` but Playwright install failed due to an environment `npm` registry `403`, so the visual capture step could not complete (non-blocking, environment issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a000bf932a0833280042f3abd19dba5)