### PR TITLE
Add UpGuard risk expansion layer

### DIFF
--- a/migrations/0003_upguard_risk_expansion.sql
+++ b/migrations/0003_upguard_risk_expansion.sql
@@ -1,0 +1,74 @@
+-- UpGuard portfolio risk profile, active vendor risks, and vendor risk diff/change-feed schema.
+
+CREATE TABLE IF NOT EXISTS portfolio_risk_profile_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  portfolio_name TEXT NOT NULL,
+  portfolio_id TEXT,
+  total_vendors INTEGER,
+  raw_json TEXT,
+  captured_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_common_risks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  snapshot_id INTEGER NOT NULL,
+  title TEXT,
+  finding TEXT,
+  category TEXT,
+  risk_type TEXT,
+  risk_subtype TEXT,
+  severity INTEGER,
+  severity_name TEXT,
+  affected_vendor_count INTEGER,
+  affected_domain_count INTEGER,
+  raw_json TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS vendor_active_risks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  vendor_primary_hostname TEXT NOT NULL,
+  risk_key TEXT,
+  title TEXT,
+  finding TEXT,
+  category TEXT,
+  risk_type TEXT,
+  risk_subtype TEXT,
+  severity INTEGER,
+  severity_name TEXT,
+  first_detected TEXT,
+  affected_hostnames_json TEXT NOT NULL DEFAULT '[]',
+  waived INTEGER DEFAULT 0,
+  raw_json TEXT,
+  captured_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_active_risks_vendor
+ON vendor_active_risks(vendor_primary_hostname);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_active_risks_severity
+ON vendor_active_risks(severity, severity_name);
+
+CREATE TABLE IF NOT EXISTS vendor_risk_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  vendor_primary_hostname TEXT NOT NULL,
+  event_type TEXT,
+  title TEXT,
+  finding TEXT,
+  category TEXT,
+  risk_type TEXT,
+  risk_subtype TEXT,
+  severity INTEGER,
+  severity_name TEXT,
+  affected_hostnames_json TEXT NOT NULL DEFAULT '[]',
+  event_start TEXT,
+  event_end TEXT,
+  raw_json TEXT,
+  captured_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_risk_events_vendor
+ON vendor_risk_events(vendor_primary_hostname);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_risk_events_captured
+ON vendor_risk_events(captured_at);

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,9 @@ const PORTFOLIO_VENDORS = [
 ];
 
 const UPGUARD_DOMAIN_ENDPOINT = "https://cyber-risk.upguard.com/api/public/vendor/domain";
+const UPGUARD_PORTFOLIO_RISK_PROFILE_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risks/vendors/all";
+const UPGUARD_VENDOR_RISKS_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risks/vendors";
+const UPGUARD_RISK_DIFF_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risk/vendors/diff";
 const DEFAULT_BATCH_SIZE = 6;
 const MAX_BATCH_SIZE = 10;
 const CURRENT_D1_TABLES = [
@@ -94,6 +97,10 @@ const CURRENT_D1_TABLES = [
   "domain_waived_check_results",
   "ingestion_runs",
   "ingestion_errors",
+  "portfolio_risk_profile_snapshots",
+  "portfolio_common_risks",
+  "vendor_active_risks",
+  "vendor_risk_events",
 ];
 const LEGACY_D1_TABLES = ["vendors", "check_results", "waived_check_results"];
 
@@ -115,6 +122,9 @@ export default {
       if (request.method === "GET" && pathname === "/api/debug/config") return json(getDebugConfig(env));
       if (request.method === "GET" && pathname === "/api/debug/secret") return json(getDebugSecret(env));
       if (request.method === "GET" && (pathname === "/api/debug/upguard-domain" || pathname === "/api/debug/upguard")) return json(await getDebugUpGuardDomain(env, url));
+      if (request.method === "GET" && pathname === "/api/debug/upguard-risk-profile") return json(await getDebugUpGuardRiskProfile(env));
+      if (request.method === "GET" && pathname === "/api/debug/upguard-vendor-risks") return json(await getDebugUpGuardVendorRisks(env, url));
+      if (request.method === "GET" && pathname === "/api/debug/upguard-risk-diff") return json(await getDebugUpGuardRiskDiff(env, url));
 
       if (request.method === "POST" && pathname === "/api/ingest") {
         const options = getIngestionOptions(url, { defaultLimit: 5, defaultBatchSize: 2 });
@@ -128,13 +138,33 @@ export default {
         return json(result, result.failureCount > 0 ? 207 : 200);
       }
 
+      if (request.method === "POST" && pathname === "/api/ingest/portfolio-risk-profile") return json(await ingestPortfolioRiskProfile(env));
+
+      if (request.method === "POST" && pathname === "/api/ingest/vendor-risks") {
+        const options = getIngestionOptions(url, { defaultLimit: 5, defaultBatchSize: 2 });
+        const result = await runVendorRiskIngestion(env, { trigger: "api_vendor_risks", ...options });
+        return json(result, result.failureCount > 0 ? 207 : 200);
+      }
+
+      if (request.method === "POST" && pathname === "/api/ingest/risk-diff") {
+        const options = getIngestionOptions(url, { defaultLimit: 5, defaultBatchSize: 2 });
+        const result = await runRiskDiffIngestion(env, { trigger: "api_risk_diff", days: url.searchParams.get("days") || 30, ...options });
+        return json(result, result.failureCount > 0 ? 207 : 200);
+      }
+
       if (request.method === "GET" && pathname === "/api/ingest/status") return json(await getIngestionStatus(env));
 
       if (request.method === "GET" && pathname === "/api/vendors") return json(await listVendors(env));
 
+      const vendorRisksMatch = pathname.match(/^\/api\/vendor\/([^/]+)\/risks$/);
+      if (request.method === "GET" && vendorRisksMatch) return json(await getVendorRisks(env, decodeURIComponent(vendorRisksMatch[1])));
+
       const vendorMatch = pathname.match(/^\/api\/vendor\/([^/]+)$/);
       if (request.method === "GET" && vendorMatch) return json(await getVendorDetail(env, decodeURIComponent(vendorMatch[1])));
 
+      if (request.method === "GET" && pathname === "/api/portfolio/risk-profile/latest") return json(await getLatestPortfolioRiskProfile(env));
+      if (request.method === "GET" && pathname === "/api/dashboard/changes") return json(await getDashboardChanges(env));
+      if (request.method === "GET" && pathname === "/api/dashboard/remediation-campaigns") return json(await getRemediationCampaigns(env));
       if (request.method === "GET" && pathname === "/api/dashboard/overview") return json(await getDashboardOverview(env));
       if (request.method === "GET" && pathname === "/api/dashboard/common-risks") return json(await getCommonRisks(env));
       if (request.method === "GET" && pathname === "/api/dashboard/severity-breakdown") return json(await getSeverityBreakdown(env));
@@ -230,6 +260,168 @@ function normalizeVendorList(vendors) {
 
 function normalizeHostname(hostname) {
   return String(hostname || "").trim().toLowerCase();
+}
+
+async function ingestPortfolioRiskProfile(env) {
+  assertDb(env);
+  assertApiKey(env);
+  await assertD1Schema(env, ["portfolio_risk_profile_snapshots", "portfolio_common_risks"]);
+  const pages = await fetchPortfolioRiskProfilePages(env);
+  const allRisks = pages.flatMap(extractRiskRecords);
+  const totalVendors = getFirstNumber(pages, ["total_vendors", "totalVendors", "vendor_count", "vendorCount", "total_count", "totalCount"]);
+  const snapshotRaw = { pages, pageCount: pages.length };
+  const insert = await env.DB.prepare(
+    `INSERT INTO portfolio_risk_profile_snapshots (portfolio_name, portfolio_id, total_vendors, raw_json)
+     VALUES (?, ?, ?, ?)`
+  ).bind(PORTFOLIO_NAME, getPortfolioId(env), totalVendors, stringifyJson(snapshotRaw)).run();
+  const snapshotId = insert.meta?.last_row_id;
+  const normalized = allRisks.map(normalizeCommonRisk).filter((risk) => risk.title || risk.finding || risk.riskType || risk.riskSubtype);
+  for (const batch of chunk(normalized.map((risk) => insertCommonRiskStatement(env.DB, snapshotId, risk)), 50)) {
+    if (batch.length) await env.DB.batch(batch);
+  }
+  const severityCounts = countBySeverity(normalized);
+  const topRisks = normalized
+    .slice()
+    .sort((a, b) => (b.affectedVendorCount || 0) - (a.affectedVendorCount || 0) || (b.severity || 0) - (a.severity || 0))
+    .slice(0, 10);
+  return { portfolioName: PORTFOLIO_NAME, portfolioId: getPortfolioId(env), snapshotId, totalVendors, riskCount: normalized.length, severityCounts, topRisks };
+}
+
+async function fetchPortfolioRiskProfilePages(env) {
+  const pages = [];
+  let pageToken = "";
+  for (let page = 0; page < 50; page += 1) {
+    const response = await fetchPortfolioRiskProfileResponse(env, pageToken);
+    const data = await parseUpGuardResponse(response, "portfolio risk profile");
+    pages.push(data);
+    pageToken = getNextPageToken(data);
+    if (!pageToken) break;
+  }
+  return pages;
+}
+
+function fetchPortfolioRiskProfileResponse(env, pageToken = "") {
+  assertPortfolioId(env);
+  const url = new URL(UPGUARD_PORTFOLIO_RISK_PROFILE_ENDPOINT);
+  url.searchParams.set("portfolios", getPortfolioId(env));
+  url.searchParams.set("page_size", "2000");
+  if (pageToken) url.searchParams.set("page_token", pageToken);
+  return fetchUpGuard(env, url);
+}
+
+async function runVendorRiskIngestion(env, { trigger = "manual", batchSize = DEFAULT_BATCH_SIZE, vendors = PORTFOLIO_VENDORS } = {}) {
+  assertDb(env);
+  assertApiKey(env);
+  await assertD1Schema(env, ["vendor_active_risks", "ingestion_errors"]);
+  const selectedVendors = normalizeVendorList(vendors);
+  const boundedBatchSize = clamp(batchSize, 1, MAX_BATCH_SIZE);
+  const startedAt = new Date().toISOString();
+  const successes = [];
+  const failures = [];
+  for (const batch of chunk(selectedVendors, boundedBatchSize)) {
+    const results = await Promise.all(batch.map((hostname) => ingestVendorActiveRisks(env, hostname)));
+    for (const result of results) result.ok ? successes.push(result.hostname) : failures.push(result);
+  }
+  return { portfolioName: PORTFOLIO_NAME, trigger, selectedVendorCount: selectedVendors.length, vendorsProcessed: selectedVendors.length, successCount: successes.length, failureCount: failures.length, failures, startedAt, completedAt: new Date().toISOString() };
+}
+
+async function ingestVendorActiveRisks(env, hostname) {
+  try {
+    const data = await fetchVendorActiveRisks(env, hostname);
+    const risks = extractRiskRecords(data).map((risk) => normalizeVendorRisk(hostname, risk));
+    await env.DB.prepare("DELETE FROM vendor_active_risks WHERE vendor_primary_hostname = ?").bind(hostname).run();
+    for (const batch of chunk(risks.map((risk) => insertVendorRiskStatement(env.DB, risk)), 50)) {
+      if (batch.length) await env.DB.batch(batch);
+    }
+    return { ok: true, hostname, riskCount: risks.length };
+  } catch (error) {
+    const failure = { ok: false, hostname, errorMessage: getErrorMessage(error), statusCode: error.statusCode || null, responseBody: error.responseBody || null };
+    await logIngestionError(env.DB, failure);
+    return failure;
+  }
+}
+
+async function fetchVendorActiveRisks(env, hostname) {
+  const response = await fetchVendorActiveRisksResponse(env, hostname);
+  return parseUpGuardResponse(response, `vendor active risks for ${hostname}`);
+}
+
+function fetchVendorActiveRisksResponse(env, hostname) {
+  const url = new URL(UPGUARD_VENDOR_RISKS_ENDPOINT);
+  url.searchParams.set("vendor_primary_hostname", hostname);
+  return fetchUpGuard(env, url);
+}
+
+async function runRiskDiffIngestion(env, { trigger = "manual", days = 30, batchSize = DEFAULT_BATCH_SIZE, vendors = PORTFOLIO_VENDORS } = {}) {
+  assertDb(env);
+  assertApiKey(env);
+  await assertD1Schema(env, ["vendor_risk_events", "ingestion_errors"]);
+  const selectedVendors = normalizeVendorList(vendors);
+  const boundedBatchSize = clamp(batchSize, 1, MAX_BATCH_SIZE);
+  const boundedDays = clamp(days, 1, 30);
+  const endDate = new Date();
+  const startDate = new Date(endDate.getTime() - boundedDays * 24 * 60 * 60 * 1000);
+  const range = { startDate: startDate.toISOString(), endDate: endDate.toISOString() };
+  const successes = [];
+  const failures = [];
+  for (const batch of chunk(selectedVendors, boundedBatchSize)) {
+    const results = await Promise.all(batch.map((hostname) => ingestRiskDiff(env, hostname, range)));
+    for (const result of results) result.ok ? successes.push(result.hostname) : failures.push(result);
+  }
+  return { portfolioName: PORTFOLIO_NAME, trigger, days: boundedDays, ...range, selectedVendorCount: selectedVendors.length, vendorsProcessed: selectedVendors.length, successCount: successes.length, failureCount: failures.length, failures, completedAt: new Date().toISOString() };
+}
+
+async function ingestRiskDiff(env, hostname, range) {
+  try {
+    const data = await fetchRiskDiff(env, hostname, range);
+    const events = normalizeRiskDiffEvents(hostname, data);
+    for (const batch of chunk(events.map((event) => insertRiskEventStatement(env.DB, event)), 50)) {
+      if (batch.length) await env.DB.batch(batch);
+    }
+    return { ok: true, hostname, eventCount: events.length };
+  } catch (error) {
+    const failure = { ok: false, hostname, errorMessage: getErrorMessage(error), statusCode: error.statusCode || null, responseBody: error.responseBody || null };
+    await logIngestionError(env.DB, failure);
+    return failure;
+  }
+}
+
+async function fetchRiskDiff(env, hostname, { startDate, endDate }) {
+  const response = await fetchRiskDiffResponse(env, hostname, startDate, endDate);
+  return parseUpGuardResponse(response, `risk diff for ${hostname}`);
+}
+
+function fetchRiskDiffResponse(env, hostname, startDate, endDate) {
+  const url = new URL(UPGUARD_RISK_DIFF_ENDPOINT);
+  url.searchParams.set("vendor_primary_hostname", hostname);
+  url.searchParams.set("start_date", startDate);
+  url.searchParams.set("end_date", endDate);
+  return fetchUpGuard(env, url);
+}
+
+async function parseUpGuardResponse(response, label) {
+  const body = await response.text();
+  const contentType = response.headers.get("content-type") || "";
+  const data = body && contentType.toLowerCase().includes("application/json") ? parseJson(body, null) : null;
+  if (!response.ok) {
+    const error = new Error(`UpGuard ${label} request failed with HTTP ${response.status}`);
+    error.statusCode = response.status;
+    error.responseBody = body.slice(0, 2000);
+    throw error;
+  }
+  return data ?? {};
+}
+
+function fetchUpGuard(env, url) {
+  return fetch(url.toString(), { headers: { "Authorization": env.UPGUARD_API_KEY, "Accept": "application/json" } });
+}
+
+function getPortfolioId(env) {
+  return String(env.UPGUARD_PORTFOLIO_ID || "").trim();
+}
+
+function assertPortfolioId(env) {
+  if (!getPortfolioId(env)) throw new Error("UPGUARD_PORTFOLIO_ID is not configured.");
 }
 
 async function getDebugUpGuardDomain(env, url) {
@@ -482,12 +674,20 @@ async function getVendorDetail(env, hostname) {
   const waivedCheckResults = await env.DB.prepare(
     "SELECT * FROM domain_waived_check_results WHERE vendor_primary_hostname = ? AND hostname = ? ORDER BY severity DESC, title ASC"
   ).bind(vendor.vendor_primary_hostname, vendor.hostname).all();
+  const activeRisks = await env.DB.prepare(
+    "SELECT * FROM vendor_active_risks WHERE vendor_primary_hostname = ? ORDER BY severity DESC, title ASC"
+  ).bind(vendor.vendor_primary_hostname).all();
+  const recentChanges = await env.DB.prepare(
+    "SELECT * FROM vendor_risk_events WHERE vendor_primary_hostname = ? ORDER BY captured_at DESC, id DESC LIMIT 50"
+  ).bind(vendor.vendor_primary_hostname).all();
 
   return {
     portfolioName: PORTFOLIO_NAME,
     vendor: hydrateVendor(vendor),
     checkResults: (checkResults.results || []).map(hydrateCheck),
     waivedCheckResults: (waivedCheckResults.results || []).map(hydrateCheck),
+    activeRisks: (activeRisks.results || []).map(hydrateStoredRisk),
+    recentChanges: (recentChanges.results || []).map(hydrateStoredRisk),
   };
 }
 
@@ -495,14 +695,36 @@ async function getDashboardOverview(env) {
   assertDb(env);
   await assertD1Schema(env);
   const totals = await env.DB.prepare(
-    `SELECT COUNT(*) AS total_vendors, COUNT(*) AS total_domains, ROUND(AVG(automated_score), 2) AS average_score FROM vendor_domains`
+    `SELECT COUNT(DISTINCT vendor_primary_hostname) AS total_vendors, COUNT(*) AS total_domains, ROUND(AVG(automated_score), 2) AS average_score FROM vendor_domains`
   ).first();
   const findings = await env.DB.prepare(
     `SELECT
-       COALESCE(SUM(CASE WHEN passed = 0 AND LOWER(COALESCE(severity_name, '')) = 'critical' THEN 1 ELSE 0 END), 0) AS critical_finding_count,
-       COALESCE(SUM(CASE WHEN passed = 0 AND LOWER(COALESCE(severity_name, '')) = 'high' THEN 1 ELSE 0 END), 0) AS high_finding_count
-     FROM domain_check_results`
+       COALESCE(SUM(CASE WHEN LOWER(COALESCE(severity_name, '')) = 'critical' OR severity >= 5 THEN 1 ELSE 0 END), 0) AS critical_active_risk_count,
+       COALESCE(SUM(CASE WHEN LOWER(COALESCE(severity_name, '')) = 'high' OR severity = 4 THEN 1 ELSE 0 END), 0) AS high_active_risk_count
+     FROM vendor_active_risks`
   ).first();
+  const changes = await env.DB.prepare(
+    `SELECT
+       COALESCE(SUM(CASE WHEN LOWER(COALESCE(event_type, '')) = 'new' THEN 1 ELSE 0 END), 0) AS new_risk_count,
+       COALESCE(SUM(CASE WHEN LOWER(COALESCE(event_type, '')) = 'resolved' THEN 1 ELSE 0 END), 0) AS resolved_risk_count
+     FROM vendor_risk_events
+     WHERE captured_at >= datetime('now', '-30 days')`
+  ).first();
+  const ingestion = await env.DB.prepare(
+    `SELECT
+       (SELECT MAX(updated_at) FROM vendor_domains) AS last_domain_ingestion_at,
+       (SELECT MAX(captured_at) FROM vendor_active_risks) AS last_vendor_risk_ingestion_at,
+       (SELECT MAX(captured_at) FROM vendor_risk_events) AS last_risk_diff_ingestion_at,
+       (SELECT MAX(captured_at) FROM portfolio_risk_profile_snapshots) AS last_portfolio_risk_profile_ingestion_at`
+  ).first();
+  const topCommon = await env.DB.prepare(
+    `SELECT pcr.title, pcr.finding, pcr.category, pcr.risk_type, pcr.risk_subtype, pcr.severity, pcr.severity_name,
+            pcr.affected_vendor_count, pcr.affected_domain_count
+     FROM portfolio_common_risks pcr
+     WHERE pcr.snapshot_id = (SELECT id FROM portfolio_risk_profile_snapshots ORDER BY id DESC LIMIT 1)
+     ORDER BY pcr.severity DESC, pcr.affected_vendor_count DESC, pcr.title ASC
+     LIMIT 10`
+  ).all();
   const categories = await env.DB.prepare(
     `SELECT category, COUNT(*) AS count
      FROM domain_check_results
@@ -525,8 +747,14 @@ async function getDashboardOverview(env) {
     totalVendors: totals?.total_vendors || 0,
     totalDomains: totals?.total_domains || 0,
     averageScore: totals?.average_score || null,
-    criticalFindingCount: findings?.critical_finding_count || 0,
-    highFindingCount: findings?.high_finding_count || 0,
+    criticalFindingCount: findings?.critical_active_risk_count || 0,
+    highFindingCount: findings?.high_active_risk_count || 0,
+    criticalActiveRiskCount: findings?.critical_active_risk_count || 0,
+    highActiveRiskCount: findings?.high_active_risk_count || 0,
+    newRiskCount30Days: changes?.new_risk_count || 0,
+    resolvedRiskCount30Days: changes?.resolved_risk_count || 0,
+    lastIngestionTimestamps: ingestion || {},
+    topCommonRisks: topCommon.results || [],
     mostCommonCategories: categories.results || [],
     mostCommonRiskTypes: riskTypes.results || [],
   };
@@ -535,22 +763,49 @@ async function getDashboardOverview(env) {
 async function getCommonRisks(env) {
   assertDb(env);
   await assertD1Schema(env);
+  const latestSnapshot = await env.DB.prepare(`SELECT id FROM portfolio_risk_profile_snapshots ORDER BY id DESC LIMIT 1`).first();
+  if (latestSnapshot) {
+    const { results } = await env.DB.prepare(
+      `SELECT title, finding, category, risk_type, risk_subtype, severity, severity_name,
+              affected_vendor_count, affected_domain_count, raw_json,
+              'upguard_portfolio_risk_profile' AS source
+       FROM portfolio_common_risks
+       WHERE snapshot_id = ?
+       ORDER BY severity DESC, affected_vendor_count DESC, title ASC`
+    ).bind(latestSnapshot.id).all();
+    return { portfolioName: PORTFOLIO_NAME, source: "upguard_portfolio_risk_profile", risks: (results || []).map((risk) => ({ ...risk, recommended_action: recommendedActionForRisk(risk) })) };
+  }
   const { results } = await env.DB.prepare(
     `SELECT
        title,
+       description AS finding,
        category,
        risk_type,
        risk_subtype,
        severity,
        severity_name,
        COUNT(DISTINCT vendor_primary_hostname) AS affected_vendor_count,
-       COUNT(DISTINCT hostname) AS affected_domain_count
+       COUNT(DISTINCT hostname) AS affected_domain_count,
+       'domain_check_results' AS source
      FROM domain_check_results
      WHERE passed = 0
-     GROUP BY title, category, severity, severity_name, risk_type, risk_subtype
+     GROUP BY title, description, category, severity, severity_name, risk_type, risk_subtype
      ORDER BY severity DESC, affected_vendor_count DESC, title ASC`
   ).all();
-  return { portfolioName: PORTFOLIO_NAME, risks: results || [] };
+  return { portfolioName: PORTFOLIO_NAME, source: "domain_check_results", risks: (results || []).map((risk) => ({ ...risk, recommended_action: recommendedActionForRisk(risk) })) };
+}
+
+function recommendedActionForRisk(risk) {
+  const campaign = classifyCampaign(risk);
+  const actions = {
+    "DMARC/SPF/DKIM/email authentication": "Publish or tighten SPF, DKIM, and DMARC records; move DMARC toward quarantine/reject after monitoring.",
+    "TLS/certificates": "Renew certificates, remove weak protocols/ciphers, and verify complete certificate chains.",
+    "security headers": "Deploy missing HTTP security headers such as HSTS, CSP, X-Frame-Options, and X-Content-Type-Options.",
+    "exposed services": "Validate business need, restrict exposure with firewall/VPN controls, and disable unnecessary services.",
+    "verified vulnerabilities / CVEs": "Patch affected assets, validate remediation, or document compensating controls with due dates.",
+    "malware/phishing/reputation": "Investigate indicators, remove malicious content, request delisting, and confirm vendor incident response.",
+  };
+  return actions[campaign] || "Review the affected vendors, confirm risk ownership, and track remediation evidence.";
 }
 
 async function getSeverityBreakdown(env) {
@@ -577,6 +832,272 @@ async function getCategories(env) {
      ORDER BY count DESC, category ASC`
   ).all();
   return { portfolioName: PORTFOLIO_NAME, categories: results || [] };
+}
+
+async function getLatestPortfolioRiskProfile(env) {
+  assertDb(env);
+  await assertD1Schema(env, ["portfolio_risk_profile_snapshots", "portfolio_common_risks"]);
+  const snapshot = await env.DB.prepare(
+    `SELECT * FROM portfolio_risk_profile_snapshots ORDER BY id DESC LIMIT 1`
+  ).first();
+  if (!snapshot) return { portfolioName: PORTFOLIO_NAME, snapshot: null, risks: [] };
+  const { results } = await env.DB.prepare(
+    `SELECT * FROM portfolio_common_risks WHERE snapshot_id = ? ORDER BY severity DESC, affected_vendor_count DESC, title ASC`
+  ).bind(snapshot.id).all();
+  return { portfolioName: PORTFOLIO_NAME, snapshot: { ...snapshot, raw: parseJson(snapshot.raw_json, {}) }, risks: (results || []).map(hydrateStoredRisk) };
+}
+
+async function getVendorRisks(env, hostname) {
+  assertDb(env);
+  await assertD1Schema(env, ["vendor_active_risks"]);
+  const cleanHostname = normalizeHostname(hostname);
+  const { results } = await env.DB.prepare(
+    `SELECT * FROM vendor_active_risks WHERE vendor_primary_hostname = ? ORDER BY severity DESC, title ASC`
+  ).bind(cleanHostname).all();
+  return { portfolioName: PORTFOLIO_NAME, hostname: cleanHostname, risks: (results || []).map(hydrateStoredRisk) };
+}
+
+async function getDashboardChanges(env) {
+  assertDb(env);
+  await assertD1Schema(env, ["vendor_risk_events"]);
+  const { results } = await env.DB.prepare(
+    `SELECT * FROM vendor_risk_events ORDER BY captured_at DESC, id DESC LIMIT 200`
+  ).all();
+  return { portfolioName: PORTFOLIO_NAME, events: (results || []).map(hydrateStoredRisk) };
+}
+
+async function getRemediationCampaigns(env) {
+  assertDb(env);
+  await assertD1Schema(env, ["portfolio_common_risks", "portfolio_risk_profile_snapshots", "vendor_active_risks"]);
+  const profile = await getLatestPortfolioRiskProfile(env);
+  const active = await env.DB.prepare(
+    `SELECT title, finding, category, risk_type, risk_subtype, severity, severity_name,
+            COUNT(DISTINCT vendor_primary_hostname) AS affected_vendor_count,
+            COUNT(*) AS affected_domain_count
+     FROM vendor_active_risks
+     GROUP BY title, finding, category, risk_type, risk_subtype, severity, severity_name
+     ORDER BY severity DESC, affected_vendor_count DESC
+     LIMIT 200`
+  ).all();
+  const combined = [...(profile.risks || []), ...(active.results || [])];
+  const campaigns = buildRemediationCampaigns(combined);
+  return { portfolioName: PORTFOLIO_NAME, campaigns };
+}
+
+async function getDebugUpGuardRiskProfile(env) {
+  assertApiKey(env);
+  const response = await fetchPortfolioRiskProfileResponse(env);
+  return summarizeDebugResponse(response);
+}
+
+async function getDebugUpGuardVendorRisks(env, url) {
+  assertApiKey(env);
+  const hostname = normalizeHostname(url.searchParams.get("hostname") || "adobe.com");
+  const response = await fetchVendorActiveRisksResponse(env, hostname);
+  const summary = await summarizeDebugResponse(response);
+  return { requestedHostname: hostname, ...summary };
+}
+
+async function getDebugUpGuardRiskDiff(env, url) {
+  assertApiKey(env);
+  const hostname = normalizeHostname(url.searchParams.get("hostname") || "adobe.com");
+  const days = clamp(url.searchParams.get("days") || 30, 1, 30);
+  const endDate = new Date();
+  const startDate = new Date(endDate.getTime() - days * 24 * 60 * 60 * 1000);
+  const response = await fetchRiskDiffResponse(env, hostname, startDate.toISOString(), endDate.toISOString());
+  const summary = await summarizeDebugResponse(response);
+  return { requestedHostname: hostname, days, startDate: startDate.toISOString(), endDate: endDate.toISOString(), ...summary };
+}
+
+async function summarizeDebugResponse(response) {
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  const data = body && contentType.toLowerCase().includes("application/json") ? parseJson(body, null) : null;
+  const records = extractRiskRecords(data);
+  const result = {
+    status: response.status,
+    ok: response.ok,
+    contentType,
+    topLevelKeys: data && typeof data === "object" && !Array.isArray(data) ? Object.keys(data) : [],
+    counts: buildDebugCounts(data, records),
+    sampleRecord: records[0] || null,
+  };
+  if (!response.ok) result.errorBody = body.slice(0, 2000);
+  return result;
+}
+
+function buildDebugCounts(data, records) {
+  const counts = { records: records.length };
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    for (const [key, value] of Object.entries(data)) {
+      if (Array.isArray(value)) counts[key] = value.length;
+    }
+  }
+  return counts;
+}
+
+function insertCommonRiskStatement(db, snapshotId, risk) {
+  return db.prepare(
+    `INSERT INTO portfolio_common_risks (
+      snapshot_id, title, finding, category, risk_type, risk_subtype, severity, severity_name,
+      affected_vendor_count, affected_domain_count, raw_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(snapshotId, risk.title, risk.finding, risk.category, risk.riskType, risk.riskSubtype, risk.severity, risk.severityName, risk.affectedVendorCount, risk.affectedDomainCount, risk.rawJson);
+}
+
+function insertVendorRiskStatement(db, risk) {
+  return db.prepare(
+    `INSERT INTO vendor_active_risks (
+      vendor_primary_hostname, risk_key, title, finding, category, risk_type, risk_subtype, severity,
+      severity_name, first_detected, affected_hostnames_json, waived, raw_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(risk.vendorPrimaryHostname, risk.riskKey, risk.title, risk.finding, risk.category, risk.riskType, risk.riskSubtype, risk.severity, risk.severityName, risk.firstDetected, risk.affectedHostnamesJson, risk.waived, risk.rawJson);
+}
+
+function insertRiskEventStatement(db, event) {
+  return db.prepare(
+    `INSERT INTO vendor_risk_events (
+      vendor_primary_hostname, event_type, title, finding, category, risk_type, risk_subtype, severity,
+      severity_name, affected_hostnames_json, event_start, event_end, raw_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(event.vendorPrimaryHostname, event.eventType, event.title, event.finding, event.category, event.riskType, event.riskSubtype, event.severity, event.severityName, event.affectedHostnamesJson, event.eventStart, event.eventEnd, event.rawJson);
+}
+
+function normalizeCommonRisk(risk) {
+  const base = normalizeRiskFields(risk);
+  return {
+    ...base,
+    affectedVendorCount: toNullableInteger(firstDefined(risk.affected_vendor_count, risk.affectedVendorCount, risk.vendor_count, risk.vendorCount, risk.vendors_count, risk.vendorsCount)),
+    affectedDomainCount: toNullableInteger(firstDefined(risk.affected_domain_count, risk.affectedDomainCount, risk.domain_count, risk.domainCount, risk.hostnames_count, risk.hostnamesCount)),
+  };
+}
+
+function normalizeVendorRisk(hostname, risk) {
+  const base = normalizeRiskFields(risk);
+  return {
+    ...base,
+    vendorPrimaryHostname: hostname,
+    riskKey: stringOrNull(firstDefined(risk.risk_key, risk.riskKey, risk.key, risk.id, risk.check_id, risk.checkId)),
+    firstDetected: stringOrNull(firstDefined(risk.first_detected, risk.firstDetected, risk.first_seen, risk.firstSeen, risk.created_at, risk.createdAt)),
+    affectedHostnamesJson: stringifyJson(extractAffectedHostnames(risk)),
+    waived: toBooleanInteger(firstDefined(risk.waived, risk.is_waived, risk.isWaived)) || 0,
+  };
+}
+
+function normalizeRiskDiffEvents(hostname, data) {
+  const eventGroups = [
+    ["new", firstDefined(data?.new, data?.new_risks, data?.newRisks, data?.created, data?.added)],
+    ["resolved", firstDefined(data?.resolved, data?.resolved_risks, data?.resolvedRisks, data?.removed)],
+    ["changed", firstDefined(data?.changed, data?.changed_risks, data?.changedRisks, data?.updated)],
+  ];
+  const grouped = eventGroups.flatMap(([eventType, value]) => asArray(value).map((risk) => normalizeRiskEvent(hostname, eventType, risk)));
+  if (grouped.length) return grouped;
+  return extractRiskRecords(data).map((risk) => normalizeRiskEvent(hostname, stringOrNull(firstDefined(risk.event_type, risk.eventType, risk.type)) || "changed", risk));
+}
+
+function normalizeRiskEvent(hostname, eventType, risk) {
+  const base = normalizeRiskFields(risk);
+  return {
+    ...base,
+    vendorPrimaryHostname: hostname,
+    eventType,
+    affectedHostnamesJson: stringifyJson(extractAffectedHostnames(risk)),
+    eventStart: stringOrNull(firstDefined(risk.event_start, risk.eventStart, risk.start_date, risk.startDate, risk.first_detected, risk.firstDetected)),
+    eventEnd: stringOrNull(firstDefined(risk.event_end, risk.eventEnd, risk.end_date, risk.endDate, risk.resolved_at, risk.resolvedAt)),
+  };
+}
+
+function normalizeRiskFields(risk) {
+  return {
+    title: stringOrNull(firstDefined(risk.title, risk.name, risk.risk_title, risk.riskTitle)),
+    finding: stringOrNull(firstDefined(risk.finding, risk.description, risk.summary, risk.check, risk.message)),
+    category: stringOrNull(firstDefined(risk.category, risk.risk_category, risk.riskCategory)),
+    riskType: stringOrNull(firstDefined(risk.risk_type, risk.riskType, risk.type)),
+    riskSubtype: stringOrNull(firstDefined(risk.risk_subtype, risk.riskSubtype, risk.subtype)),
+    severity: toNullableInteger(firstDefined(risk.severity, risk.severity_score, risk.severityScore)),
+    severityName: stringOrNull(firstDefined(risk.severity_name, risk.severityName, risk.severity_label, risk.severityLabel)),
+    rawJson: stringifyJson(risk),
+  };
+}
+
+function extractRiskRecords(data) {
+  if (Array.isArray(data)) return data;
+  if (!data || typeof data !== "object") return [];
+  for (const key of ["risks", "results", "records", "data", "items", "common_risks", "commonRisks", "vendor_risks", "vendorRisks"]) {
+    if (Array.isArray(data[key])) return data[key];
+  }
+  return [];
+}
+
+function extractAffectedHostnames(risk) {
+  const source = firstDefined(risk.affected_hostnames, risk.affectedHostnames, risk.hostnames, risk.hosts, risk.domains, risk.affected_domains, risk.affectedDomains);
+  return asArray(source).map((item) => typeof item === "string" ? item : firstDefined(item.hostname, item.domain, item.name)).filter(Boolean);
+}
+
+function getNextPageToken(data) {
+  return stringOrNull(firstDefined(data?.next_page_token, data?.nextPageToken, data?.next_token, data?.nextToken));
+}
+
+function getFirstNumber(objects, keys) {
+  for (const object of objects) {
+    for (const key of keys) {
+      const value = object?.[key];
+      if (value != null && Number.isFinite(Number(value))) return Number(value);
+    }
+  }
+  return null;
+}
+
+function countBySeverity(risks) {
+  return risks.reduce((counts, risk) => {
+    const key = risk.severityName || risk.severity || "Unknown";
+    counts[key] = (counts[key] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+function buildRemediationCampaigns(risks) {
+  const groups = new Map();
+  for (const risk of risks) {
+    const campaign = classifyCampaign(risk);
+    const current = groups.get(campaign) || { campaign, riskCount: 0, affectedVendorCount: 0, affectedDomainCount: 0, maxSeverity: null, risks: [] };
+    current.riskCount += 1;
+    current.affectedVendorCount += Number(risk.affected_vendor_count ?? risk.affectedVendorCount ?? 0);
+    current.affectedDomainCount += Number(risk.affected_domain_count ?? risk.affectedDomainCount ?? 0);
+    current.maxSeverity = Math.max(current.maxSeverity || 0, Number(risk.severity || 0));
+    if (current.risks.length < 8) current.risks.push(risk);
+    groups.set(campaign, current);
+  }
+  return [...groups.values()].sort((a, b) => b.maxSeverity - a.maxSeverity || b.affectedVendorCount - a.affectedVendorCount);
+}
+
+function classifyCampaign(risk) {
+  const text = [risk.title, risk.finding, risk.category, risk.risk_type, risk.riskType, risk.risk_subtype, risk.riskSubtype].filter(Boolean).join(" ").toLowerCase();
+  if (/dmarc|spf|dkim|email/.test(text)) return "DMARC/SPF/DKIM/email authentication";
+  if (/tls|ssl|certificate|cert/.test(text)) return "TLS/certificates";
+  if (/header|hsts|csp|x-frame|x-content/.test(text)) return "security headers";
+  if (/port|service|rdp|ssh|ftp|exposed/.test(text)) return "exposed services";
+  if (/cve|vulnerab|patch|exploit/.test(text)) return "verified vulnerabilities / CVEs";
+  if (/malware|phishing|reputation|blacklist/.test(text)) return "malware/phishing/reputation";
+  return "other remediation";
+}
+
+function hydrateStoredRisk(risk) {
+  return { ...risk, affectedHostnames: parseJson(risk.affected_hostnames_json, []), raw: parseJson(risk.raw_json, {}) };
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === "object") return Object.values(value).flatMap((item) => Array.isArray(item) ? item : []);
+  return [];
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== "");
+}
+
+function stringOrNull(value) {
+  return value == null || value === "" ? null : String(value);
 }
 
 function hydrateVendor(vendor) {
@@ -652,6 +1173,8 @@ function getDebugConfig(env) {
     hasDb: Boolean(env.DB),
     hasUpGuardApiKey: Boolean(apiKey.trim()),
     apiKeyLength: apiKey.length,
+    hasUpGuardPortfolioId: Boolean(getPortfolioId(env)),
+    portfolioIdLength: getPortfolioId(env).length,
     portfolioName: PORTFOLIO_NAME,
     configuredVendorCount: PORTFOLIO_VENDORS.length,
     databaseBindingNameExpected: "DB",
@@ -790,13 +1313,12 @@ function renderDashboardShell() {
     h2 { margin: 0 0 16px; font-size: 20px; }
     p { color: #9fb0ca; }
     main { padding: 24px clamp(18px, 4vw, 56px) 56px; display: grid; gap: 22px; }
-    .tabs { display: flex; flex-wrap: wrap; gap: 10px; }
+    .tabs, .actions { display: flex; flex-wrap: wrap; gap: 10px; }
     button, .tab { border: 0; border-radius: 999px; background: #15243a; color: #dbeafe; padding: 10px 15px; cursor: pointer; font-weight: 700; }
     button:hover, .tab.active { background: #2f6fed; color: white; }
     .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; }
     .card { background: rgba(15, 23, 42, .82); border: 1px solid rgba(148,163,184,.18); border-radius: 22px; padding: 20px; box-shadow: 0 20px 60px rgba(0,0,0,.25); }
     .error-card { border-color: rgba(248,113,113,.55); background: rgba(127, 29, 29, .35); }
-    .error-card h2 { color: #fecaca; }
     .empty { border-style: dashed; text-align: center; color: #cbd5e1; }
     .metric { font-size: 34px; font-weight: 800; margin: 6px 0; }
     table { width: 100%; border-collapse: collapse; overflow: hidden; }
@@ -808,135 +1330,103 @@ function renderDashboardShell() {
     .split { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
     .muted { color: #94a3b8; } .link { color: #93c5fd; cursor: pointer; font-weight: 800; }
     .hidden { display: none; }
-    pre { white-space: pre-wrap; overflow: auto; background: #020617; border-radius: 14px; padding: 14px; color: #cbd5e1; }
+    pre { white-space: pre-wrap; overflow: auto; background: #020617; border-radius: 14px; padding: 14px; color: #cbd5e1; max-height: 360px; }
     @media (max-width: 980px) { .grid, .split { grid-template-columns: 1fr; } }
   </style>
 </head>
 <body>
   <header>
     <h1>Third-Party Risk Intelligence</h1>
-    <p>${PORTFOLIO_NAME} · UpGuard domain risk ingestion persisted in Cloudflare D1.</p>
+    <p>${PORTFOLIO_NAME} · UpGuard domain, portfolio risk, active risk, and change-feed ingestion persisted in Cloudflare D1.</p>
     <div class="tabs">
-      <button data-view="overview">Overview</button>
+      <button data-view="overview">Portfolio Overview</button>
       <button data-view="vendors">Vendors</button>
       <button data-view="common-risks">Common Risks</button>
+      <button data-view="changes">Changes Feed</button>
+      <button data-view="campaigns">Remediation Campaigns</button>
       <button data-view="severity">Severity Breakdown</button>
-      <button id="ingest">Run Ingestion</button>
     </div>
   </header>
   <main>
     <section id="status" class="card muted">Loading dashboard data…</section>
+    <section class="card"><h2>Ingestion Controls</h2><div class="actions"><button data-ingest="domains">Ingest Domains</button><button data-ingest="portfolio">Ingest Portfolio Risk Profile</button><button data-ingest="vendorRisks">Ingest Vendor Active Risks</button><button data-ingest="riskDiff">Ingest 30-Day Risk Diff</button></div><pre id="ingest-log" class="muted">Idle. Chunked vendor jobs use limit=5, batchSize=2, and offset pagination.</pre></section>
     <section id="overview" class="view"></section>
     <section id="vendors" class="view hidden"></section>
     <section id="common-risks" class="view hidden"></section>
+    <section id="changes" class="view hidden"></section>
+    <section id="campaigns" class="view hidden"></section>
     <section id="severity" class="view hidden"></section>
     <section id="vendor-detail" class="view hidden"></section>
   </main>
 <script>
 const EMPTY_MESSAGE = 'No domain data has been ingested yet. Run ingestion to populate D1.';
-const state = { overview: null, vendors: [], risks: [], severities: [], categories: [], errors: {} };
-const $ = (id) => document.getElementById(id);
-const esc = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
-const jsString = (value) => JSON.stringify(String(value ?? ''));
-const badge = (name) => '<span class="badge ' + esc(String(name || '').toLowerCase()) + '">' + esc(name || 'Unknown') + '</span>';
-const emptyCard = () => '<div class="card empty"><p>' + EMPTY_MESSAGE + '</p></div>';
-const API_TIMEOUT_MS = 20000;
-async function api(path, options = {}) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-  let response;
-  let data = null;
-  let text = '';
-
-  try {
-    response = await fetch(path, { ...options, signal: controller.signal });
-    text = await response.text();
-    data = text ? JSON.parse(text) : null;
-  } catch (error) {
-    if (error.name === 'AbortError') throw new Error(path + ' timed out after ' + API_TIMEOUT_MS + 'ms');
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  if (!response.ok) throw new Error((data && (data.message || data.error)) || text || response.statusText);
-  return data;
-}
+const state = { overview: null, vendors: [], risks: [], severities: [], categories: [], changes: [], campaigns: [], errors: {} };
+const $ = id => document.getElementById(id);
+function esc(value) { return String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+function jsString(value) { return JSON.stringify(String(value || '')); }
+function badge(value) { const v = String(value || 'unknown'); return '<span class="badge ' + esc(v.toLowerCase()) + '">' + esc(v) + '</span>'; }
+async function api(path, options) { const r = await fetch(path, options); const data = await r.json().catch(() => ({})); if (!r.ok && r.status !== 207) throw new Error(data.message || data.error || 'HTTP ' + r.status); return data; }
 async function load() {
   state.errors = {};
   const endpoints = [
-    { key: 'overview', label: 'Overview', path: '/api/dashboard/overview', apply: (data) => { state.overview = data || {}; } },
-    { key: 'vendors', label: 'Vendors', path: '/api/vendors', apply: (data) => { state.vendors = data.vendors || []; } },
-    { key: 'risks', label: 'Common risks', path: '/api/dashboard/common-risks', apply: (data) => { state.risks = data.risks || []; } },
-    { key: 'severities', label: 'Severity breakdown', path: '/api/dashboard/severity-breakdown', apply: (data) => { state.severities = data.severities || []; } },
-    { key: 'categories', label: 'Categories', path: '/api/dashboard/categories', apply: (data) => { state.categories = data.categories || []; } },
+    ['overview', '/api/dashboard/overview', d => state.overview = d],
+    ['vendors', '/api/vendors', d => state.vendors = d.vendors || []],
+    ['risks', '/api/dashboard/common-risks', d => state.risks = d.risks || []],
+    ['changes', '/api/dashboard/changes', d => state.changes = d.events || []],
+    ['campaigns', '/api/dashboard/remediation-campaigns', d => state.campaigns = d.campaigns || []],
+    ['severities', '/api/dashboard/severity-breakdown', d => state.severities = d.severities || []],
+    ['categories', '/api/dashboard/categories', d => state.categories = d.categories || []]
   ];
-
-  const results = await Promise.allSettled(endpoints.map((endpoint) => api(endpoint.path)));
   let successCount = 0;
-
-  results.forEach((result, index) => {
-    const endpoint = endpoints[index];
-    if (result.status === 'fulfilled') {
-      successCount += 1;
-      endpoint.apply(result.value || {});
-    } else {
-      state.errors[endpoint.key] = { ...endpoint, message: result.reason?.message || String(result.reason) };
-    }
-  });
-
+  await Promise.all(endpoints.map(async ([key, path, assign]) => { try { assign(await api(path)); successCount += 1; } catch (e) { state.errors[key] = { label: key, message: e.message }; } }));
   const failureCount = endpoints.length - successCount;
-  const emptySuffix = state.vendors.length === 0 ? ' ' + EMPTY_MESSAGE : ' Loaded ' + state.vendors.length + ' domains.';
-  $('status').innerHTML = successCount + ' of ' + endpoints.length + ' dashboard endpoints loaded. ' +
-    (failureCount ? 'Review the error cards below; loaded sections remain available.' : emptySuffix);
-  renderOverview(); renderVendors(); renderRisks(); renderSeverity();
+  const emptySuffix = !failureCount && !state.vendors.length ? ' ' + EMPTY_MESSAGE : '';
+  $('status').innerHTML = successCount + ' of ' + endpoints.length + ' dashboard endpoints loaded. ' + (failureCount ? 'Review the error cards below; loaded sections remain available.' : emptySuffix);
+  renderOverview(); renderVendors(); renderRisks(); renderChanges(); renderCampaigns(); renderSeverity();
 }
 function renderOverview() {
-  const o = state.overview || {};
+  const o = state.overview || {}; const times = o.lastIngestionTimestamps || {};
   $('overview').innerHTML = errorCard('overview') + (Number(o.totalDomains || o.totalVendors || 0) === 0 ? emptyCard() : '') + '<div class="grid">' +
-    metric('Total domains/vendors', o.totalDomains ?? o.totalVendors) + metric('Average score', o.averageScore ?? '—') + metric('Critical findings', o.criticalFindingCount) + metric('High findings', o.highFindingCount) +
-    '</div><div class="split"><div class="card"><h2>Most common categories</h2>' + list(o.mostCommonCategories, 'category') + '</div><div class="card"><h2>Most common risk types</h2>' + list(o.mostCommonRiskTypes, 'risk_type') + '</div></div>';
+    metric('Total vendors', o.totalVendors) + metric('Total domains', o.totalDomains) + metric('Average score', o.averageScore ?? '—') + metric('Critical/high active risks', (o.criticalActiveRiskCount || 0) + '/' + (o.highActiveRiskCount || 0)) +
+    metric('New risks in 30 days', o.newRiskCount30Days) + metric('Resolved in 30 days', o.resolvedRiskCount30Days) + metric('Last portfolio profile', times.last_portfolio_risk_profile_ingestion_at || '—') + metric('Last risk diff', times.last_risk_diff_ingestion_at || '—') +
+    '</div><div class="split"><div class="card"><h2>Top common UpGuard risks</h2>' + riskTable(o.topCommonRisks || []) + '</div><div class="card"><h2>Last ingestion timestamps</h2>' + keyValueTable(times) + '</div></div>';
 }
 function renderVendors() {
   const rows = state.vendors || [];
-  const body = rows.length ? rows.map(v => {
-    const hostname = v.hostname || v.vendor_primary_hostname || '';
-    return '<tr><td><span class="link" onclick="showVendor(' + esc(jsString(hostname)) + ')">' + esc(hostname) + '</span></td><td>' + esc(v.vendor_primary_hostname || hostname) + '</td><td>' + esc(v.score ?? v.automated_score ?? '—') + '</td><td>' + esc(v.scanned_at || '—') + '</td><td>' + esc(v.total_checks ?? 0) + '</td><td>' + esc(v.failed_checks ?? 0) + '</td><td>' + esc(v.waived_checks ?? 0) + '</td></tr>';
-  }).join('') : '<tr><td colspan="7">' + EMPTY_MESSAGE + '</td></tr>';
+  const body = rows.length ? rows.map(v => { const hostname = v.hostname || v.vendor_primary_hostname || ''; return '<tr><td><span class="link" onclick="showVendor(' + esc(jsString(hostname)) + ')">' + esc(hostname) + '</span></td><td>' + esc(v.vendor_primary_hostname || hostname) + '</td><td>' + esc(v.score ?? v.automated_score ?? '—') + '</td><td>' + esc(v.scanned_at || '—') + '</td><td>' + esc(v.total_checks ?? 0) + '</td><td>' + esc(v.failed_checks ?? 0) + '</td><td>' + esc(v.waived_checks ?? 0) + '</td></tr>'; }).join('') : '<tr><td colspan="7">' + EMPTY_MESSAGE + '</td></tr>';
   $('vendors').innerHTML = errorCard('vendors') + '<div class="card"><h2>Vendor Domain Table</h2><table><thead><tr><th>Hostname</th><th>Vendor primary hostname</th><th>Automated score</th><th>Scanned</th><th>Total checks</th><th>Failed</th><th>Waived</th></tr></thead><tbody>' + body + '</tbody></table></div>';
 }
-function renderRisks() {
-  const rows = state.risks || [];
-  const body = rows.length ? rows.map(r => '<tr><td>' + esc(r.title || 'Untitled') + '</td><td>' + esc(r.category || 'Uncategorized') + '</td><td>' + esc(r.risk_type || 'Unknown') + '</td><td>' + badge(r.severity_name || r.severity) + '</td><td>' + esc(r.affected_vendor_count ?? 0) + '</td><td>' + esc(r.affected_domain_count ?? 0) + '</td></tr>').join('') : '<tr><td colspan="6">No failed active checks are available.</td></tr>';
-  $('common-risks').innerHTML = errorCard('risks') + '<div class="card"><h2>Common Risks</h2><table><thead><tr><th>Risk</th><th>Category</th><th>Risk type</th><th>Severity</th><th>Affected vendors</th><th>Affected domains</th></tr></thead><tbody>' + body + '</tbody></table></div>';
+function renderRisks() { $('common-risks').innerHTML = errorCard('risks') + '<div class="card"><h2>Common Risks</h2>' + riskTable(state.risks || [], true) + '</div>'; }
+function renderChanges() {
+  const rows = state.changes || [];
+  const body = rows.length ? rows.map(e => '<tr><td>' + esc(e.vendor_primary_hostname) + '</td><td>' + esc(e.event_type || 'changed') + '</td><td>' + esc(e.title || e.finding || 'Untitled') + '</td><td>' + badge(e.severity_name || e.severity) + '</td><td>' + esc((e.affectedHostnames || []).join(', ')) + '</td><td>' + esc(e.captured_at || '—') + '</td></tr>').join('') : '<tr><td colspan="6">No risk diff events are available.</td></tr>';
+  $('changes').innerHTML = errorCard('changes') + '<div class="card"><h2>Changes Feed</h2><table><thead><tr><th>Vendor</th><th>Event</th><th>Risk/finding</th><th>Severity</th><th>Affected hostnames</th><th>Captured</th></tr></thead><tbody>' + body + '</tbody></table></div>';
 }
-function renderSeverity() {
-  $('severity').innerHTML = errorCard('severities') + errorCard('categories') + '<div class="split"><div class="card"><h2>Severity Breakdown</h2>' + list(state.severities, 'severity_name') + '</div><div class="card"><h2>Category Grouping</h2>' + list(state.categories, 'category') + '</div></div>';
+function renderCampaigns() {
+  const rows = state.campaigns || [];
+  const body = rows.length ? rows.map(c => '<tr><td>' + esc(c.campaign) + '</td><td>' + esc(c.riskCount) + '</td><td>' + esc(c.affectedVendorCount) + '</td><td>' + esc(c.affectedDomainCount) + '</td><td>' + badge(c.maxSeverity) + '</td></tr>').join('') : '<tr><td colspan="5">No campaign data is available.</td></tr>';
+  $('campaigns').innerHTML = errorCard('campaigns') + '<div class="card"><h2>Remediation Campaigns</h2><table><thead><tr><th>Campaign</th><th>Risk count</th><th>Affected vendors</th><th>Affected domains</th><th>Max severity</th></tr></thead><tbody>' + body + '</tbody></table></div>';
 }
+function renderSeverity() { $('severity').innerHTML = errorCard('severities') + errorCard('categories') + '<div class="split"><div class="card"><h2>Severity Breakdown</h2>' + list(state.severities, 'severity_name') + '</div><div class="card"><h2>Category Grouping</h2>' + list(state.categories, 'category') + '</div></div>'; }
 async function showVendor(hostname) {
-  show('vendor-detail');
-  $('vendor-detail').innerHTML = '<div class="card">Loading ' + esc(hostname) + '…</div>';
-  try {
-    const data = await api('/api/vendor/' + encodeURIComponent(hostname));
-    const vendor = data.vendor || {};
-    $('vendor-detail').innerHTML = '<div class="card"><h2>' + esc(vendor.hostname || hostname) + '</h2><p>Vendor primary hostname: <strong>' + esc(vendor.vendor_primary_hostname || '—') + '</strong></p><p>Score: <strong>' + esc(vendor.automated_score ?? vendor.score ?? '—') + '</strong> · Scanned: ' + esc(vendor.scanned_at || '—') + '</p></div>' +
-      '<div class="split"><div class="card"><h2>Active Checks</h2>' + checkTable(data.checkResults || []) + '</div><div class="card"><h2>Waived Checks</h2>' + checkTable(data.waivedCheckResults || []) + '</div></div>';
-  } catch (error) {
-    $('vendor-detail').innerHTML = '<div class="card error-card"><h2>Vendor failed to load</h2><p>' + esc(error.message) + '</p></div>';
-  }
+  show('vendor-detail'); $('vendor-detail').innerHTML = '<div class="card">Loading ' + esc(hostname) + '…</div>';
+  try { const data = await api('/api/vendor/' + encodeURIComponent(hostname)); const vendor = data.vendor || {}; $('vendor-detail').innerHTML = '<div class="card"><h2>' + esc(vendor.hostname || hostname) + '</h2><p>Vendor primary hostname: <strong>' + esc(vendor.vendor_primary_hostname || '—') + '</strong></p><p>Score: <strong>' + esc(vendor.automated_score ?? vendor.score ?? '—') + '</strong> · Scanned: ' + esc(vendor.scanned_at || '—') + '</p></div>' + '<div class="card"><h2>Domain scan checks</h2>' + checkTable(data.checkResults || []) + '</div><div class="split"><div class="card"><h2>Active Risks</h2>' + riskTable(data.activeRisks || []) + '</div><div class="card"><h2>Recent Changes</h2>' + eventMiniTable(data.recentChanges || []) + '</div></div><div class="card"><h2>Waived Checks</h2>' + checkTable(data.waivedCheckResults || []) + '</div>'; } catch (error) { $('vendor-detail').innerHTML = '<div class="card error-card"><h2>Vendor failed to load</h2><p>' + esc(error.message) + '</p></div>'; }
 }
-function checkTable(rows) {
-  if (!rows.length) return '<p class="muted">No check rows available.</p>';
-  return '<table><thead><tr><th>Title</th><th>Category</th><th>Severity</th><th>Passed</th></tr></thead><tbody>' + rows.map(c => '<tr><td>' + esc(c.title || c.check_id || 'Untitled') + '</td><td>' + esc(c.category || 'Uncategorized') + '</td><td>' + badge(c.severity_name || c.severity) + '</td><td>' + (c.passed === null ? 'Unknown' : c.passed ? 'Yes' : 'No') + '</td></tr>').join('') + '</tbody></table>';
-}
+function riskTable(rows, includeAction) { if (!rows.length) return '<p class="muted">No risk rows available.</p>'; return '<table><thead><tr><th>Risk/finding</th><th>Severity</th><th>Category</th><th>Type/subtype</th><th>Vendors</th><th>Domains</th>' + (includeAction ? '<th>Recommended action</th>' : '') + '</tr></thead><tbody>' + rows.map(r => '<tr><td>' + esc(r.title || r.finding || 'Untitled') + '</td><td>' + badge(r.severity_name || r.severity) + '</td><td>' + esc(r.category || 'Uncategorized') + '</td><td>' + esc([r.risk_type, r.risk_subtype].filter(Boolean).join(' / ') || 'Unknown') + '</td><td>' + esc(r.affected_vendor_count ?? 0) + '</td><td>' + esc(r.affected_domain_count ?? 0) + '</td>' + (includeAction ? '<td>' + esc(r.recommended_action || 'Review and remediate.') + '</td>' : '') + '</tr>').join('') + '</tbody></table>'; }
+function eventMiniTable(rows) { if (!rows.length) return '<p class="muted">No recent changes.</p>'; return '<table><thead><tr><th>Event</th><th>Risk</th><th>Severity</th><th>Captured</th></tr></thead><tbody>' + rows.map(e => '<tr><td>' + esc(e.event_type || 'changed') + '</td><td>' + esc(e.title || e.finding || 'Untitled') + '</td><td>' + badge(e.severity_name || e.severity) + '</td><td>' + esc(e.captured_at || '—') + '</td></tr>').join('') + '</tbody></table>'; }
+function checkTable(rows) { if (!rows.length) return '<p class="muted">No check rows available.</p>'; return '<table><thead><tr><th>Title</th><th>Category</th><th>Severity</th><th>Passed</th></tr></thead><tbody>' + rows.map(c => '<tr><td>' + esc(c.title || c.check_id || 'Untitled') + '</td><td>' + esc(c.category || 'Uncategorized') + '</td><td>' + badge(c.severity_name || c.severity) + '</td><td>' + (c.passed === null ? 'Unknown' : c.passed ? 'Yes' : 'No') + '</td></tr>').join('') + '</tbody></table>'; }
+function keyValueTable(obj) { const rows = Object.entries(obj || {}); return rows.length ? '<table><tbody>' + rows.map(([k,v]) => '<tr><td>' + esc(k) + '</td><td>' + esc(v || '—') + '</td></tr>').join('') + '</tbody></table>' : '<p class="muted">No ingestion timestamps yet.</p>'; }
 function metric(label, value) { return '<div class="card"><div class="muted">' + esc(label) + '</div><div class="metric">' + esc(value ?? 0) + '</div></div>'; }
 function list(rows, key) { return rows && rows.length ? '<table><tbody>' + rows.map(row => '<tr><td>' + esc(row[key] || 'Unknown') + '</td><td>' + esc(row.count) + '</td></tr>').join('') + '</tbody></table>' : '<p class="muted">No failed active checks are available.</p>'; }
+function emptyCard() { return '<div class="card empty"><h2>No ingested data yet</h2><p>' + EMPTY_MESSAGE + '</p></div>'; }
 function errorCard(key) { const error = state.errors[key]; return error ? '<div class="card error-card"><h2>' + esc(error.label) + ' failed to load</h2><p>' + esc(error.message) + '</p></div>' : ''; }
 function show(view) { document.querySelectorAll('.view').forEach(el => el.classList.add('hidden')); $(view).classList.remove('hidden'); document.querySelectorAll('[data-view]').forEach(btn => btn.classList.toggle('active', btn.dataset.view === view)); }
+async function runChunked(path, label) { const log = $('ingest-log'); let offset = 0; let totalSuccess = 0; let totalFailures = 0; for (;;) { const sep = path.includes('?') ? '&' : '?'; const url = path + sep + 'limit=5&batchSize=2&offset=' + offset; log.textContent = label + ': running chunk offset ' + offset + '…\n' + log.textContent; const result = await api(url, { method: 'POST' }); totalSuccess += result.successCount || 0; totalFailures += result.failureCount || 0; log.textContent = label + ': finished offset ' + offset + ', successes=' + totalSuccess + ', failures=' + totalFailures + '\n' + JSON.stringify(result, null, 2); if ((result.selectedVendorCount || 0) < 5) break; offset += 5; } await load(); }
 document.querySelectorAll('[data-view]').forEach(btn => btn.addEventListener('click', () => show(btn.dataset.view)));
-$('ingest').addEventListener('click', async () => { $('status').innerHTML = 'Ingestion running…'; try { const result = await api('/api/ingest', { method: 'POST' }); $('status').innerHTML = '<pre>' + esc(JSON.stringify(result, null, 2)) + '</pre>'; await load(); } catch (e) { $('status').innerHTML = esc(e.message); renderOverview(); renderVendors(); renderRisks(); renderSeverity(); } });
+document.querySelectorAll('[data-ingest]').forEach(btn => btn.addEventListener('click', async () => { try { const job = btn.dataset.ingest; if (job === 'domains') await runChunked('/api/ingest/chunk', 'Domain ingestion'); if (job === 'portfolio') { $('ingest-log').textContent = 'Portfolio risk profile ingestion running…'; $('ingest-log').textContent = JSON.stringify(await api('/api/ingest/portfolio-risk-profile', { method: 'POST' }), null, 2); await load(); } if (job === 'vendorRisks') await runChunked('/api/ingest/vendor-risks', 'Vendor active risks'); if (job === 'riskDiff') await runChunked('/api/ingest/risk-diff?days=30', '30-day risk diff'); } catch (e) { $('ingest-log').textContent = 'Ingestion failed: ' + e.message; } }));
 show('overview'); load();
 </script>
 </body>
 </html>`;
 }
+

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,11 +19,13 @@ database_id = "0aae51e4-fca2-4f5a-8dd2-2f9ea7b50e67"
 # - UPGUARD_API_KEY (set with `wrangler secret put UPGUARD_API_KEY`)
 [vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_PORTFOLIO_ID = ""
 
 [env.staging]
 # Keep same entry file; secrets are environment-specific.
 [env.staging.vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_PORTFOLIO_ID = ""
 
 [[env.staging.d1_databases]]
 binding = "DB"
@@ -33,6 +35,7 @@ database_id = "0aae51e4-fca2-4f5a-8dd2-2f9ea7b50e67"
 [env.production]
 [env.production.vars]
 REQUIRE_ACCESS = "0"
+UPGUARD_PORTFOLIO_ID = ""
 
 [[env.production.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
### Motivation

- Expand the dashboard to ingest and surface portfolio-wide UpGuard data (common risks), per-vendor active risks, and vendor risk diffs/change-feed so the UI can show portfolio common risks and a change feed in addition to existing domain checks. 
- Provide chunked, user-triggered ingestion flows to avoid frontend timeouts and ensure long-running UpGuard calls are paginated and resumable. 
- Persist portfolio snapshots, normalized common risks, vendor active risks, and risk events in D1 while preserving the existing `DB` binding and domain-centric tables.

### Description

- Added new UpGuard endpoints and environment config including `UPGUARD_PORTFOLIO_ID` and constants `UPGUARD_PORTFOLIO_RISK_PROFILE_ENDPOINT`, `UPGUARD_VENDOR_RISKS_ENDPOINT`, and `UPGUARD_RISK_DIFF_ENDPOINT`, and kept the D1 binding as `env.DB` (no binding changes). 
- Created a new migration `migrations/0003_upguard_risk_expansion.sql` that adds `portfolio_risk_profile_snapshots`, `portfolio_common_risks`, `vendor_active_risks`, and `vendor_risk_events` plus the requested indexes. 
- Implemented ingestion and query APIs: `POST /api/ingest/portfolio-risk-profile`, `POST /api/ingest/vendor-risks`, `POST /api/ingest/risk-diff`, `GET /api/portfolio/risk-profile/latest`, `GET /api/vendor/:hostname/risks`, `GET /api/dashboard/changes`, and debug endpoints `GET /api/debug/upguard-risk-profile`, `GET /api/debug/upguard-vendor-risks`, `GET /api/debug/upguard-risk-diff`; ingestion logic fetches UpGuard pages, normalizes records, continues on per-vendor failure, and logs to `ingestion_errors`. 
- Added robust UpGuard response parsing/normalization utilities (`parseUpGuardResponse`, `extractRiskRecords`, `normalizeCommonRisk`, `normalizeVendorRisk`, `normalizeRiskDiffEvents`, etc.), insert statement builders, and RFC3339 date handling for the diff feed with a 30-day max interval. 
- Extended the dashboard UI and client-side logic to include Portfolio Overview, Common Risks, Changes Feed, Remediation Campaigns, enhanced Vendor Detail (active risks + recent changes), and chunked ingestion controls that use `limit=5`, `batchSize=2`, and offset pagination to avoid timeouts. 

### Testing

- Ran `node --check src/index.js` to validate syntax and it completed successfully. 
- Executed the migrations locally into a temporary SQLite DB with `tmpdb=$(mktemp); for f in migrations/*.sql; do sqlite3 "$tmpdb" < "$f"; done; sqlite3 "$tmpdb" ".tables"; rm "$tmpdb"` which produced the expected new tables and indexes. 
- Performed a Wrangler dry-run with `npx wrangler deploy --dry-run --outdir /tmp/tprdashboard-worker` to verify the worker package and bindings; the dry-run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a007c3ce1208332905a413d2155b373)