### PR TITLE
Fix UpGuard risk diff vendor hostname parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,7 +238,7 @@ async function runIngestion(env, { trigger = "manual", batchSize = DEFAULT_BATCH
 
 function getIngestionOptions(url, { defaultLimit = PORTFOLIO_VENDORS.length, defaultBatchSize = DEFAULT_BATCH_SIZE } = {}) {
   const hasQueryParameters = Array.from(url.searchParams.keys()).length > 0;
-  const hostname = normalizeHostname(url.searchParams.get("hostname"));
+  const hostname = normalizeHostname(url.searchParams.get("vendor_primary_hostname")) || normalizeHostname(url.searchParams.get("hostname"));
   const batchSize = url.searchParams.has("batchSize")
     ? clamp(url.searchParams.get("batchSize"), 1, MAX_BATCH_SIZE)
     : hasQueryParameters
@@ -440,12 +440,21 @@ async function fetchRiskDiff(env, hostname, { startDate, endDate }) {
   return parseUpGuardResponse(response, `risk diff for ${hostname}`);
 }
 
-function fetchRiskDiffResponse(env, hostname, startDate, endDate) {
+function buildRiskDiffUrl(hostname, startDate, endDate) {
+  const vendorPrimaryHostname = normalizeHostname(hostname);
+  if (!vendorPrimaryHostname) {
+    throw new Error("Missing vendor_primary_hostname for risk diff request.");
+  }
+
   const url = new URL(UPGUARD_RISK_DIFF_ENDPOINT);
-  url.searchParams.set("vendor_primary_hostname", hostname);
+  url.searchParams.set("vendor_primary_hostname", vendorPrimaryHostname);
   url.searchParams.set("start_date", startDate);
   url.searchParams.set("end_date", endDate);
-  return fetchUpGuard(env, url);
+  return url;
+}
+
+function fetchRiskDiffResponse(env, hostname, startDate, endDate) {
+  return fetchUpGuard(env, buildRiskDiffUrl(hostname, startDate, endDate));
 }
 
 async function parseUpGuardResponse(response, label) {
@@ -976,13 +985,32 @@ async function getDebugUpGuardVendorRisks(env, url) {
 
 async function getDebugUpGuardRiskDiff(env, url) {
   assertApiKey(env);
-  const hostname = normalizeHostname(url.searchParams.get("hostname") || "adobe.com");
+  const vendorPrimaryHostname =
+    normalizeHostname(url.searchParams.get("vendor_primary_hostname")) ||
+    normalizeHostname(url.searchParams.get("hostname")) ||
+    "adobe.com";
   const days = clamp(url.searchParams.get("days") || 30, 1, 30);
   const endDate = new Date();
   const startDate = new Date(endDate.getTime() - days * 24 * 60 * 60 * 1000);
-  const response = await fetchRiskDiffResponse(env, hostname, startDate.toISOString(), endDate.toISOString());
+  const startDateIso = startDate.toISOString();
+  const endDateIso = endDate.toISOString();
+  const upstreamUrl = buildRiskDiffUrl(vendorPrimaryHostname, startDateIso, endDateIso);
+  const response = await fetchUpGuard(env, upstreamUrl);
   const summary = await summarizeDebugResponse(response);
-  return { requestedHostname: hostname, days, startDate: startDate.toISOString(), endDate: endDate.toISOString(), ...summary };
+  return {
+    requestedHostname: vendorPrimaryHostname,
+    vendorPrimaryHostname,
+    days,
+    startDate: startDateIso,
+    endDate: endDateIso,
+    upstreamUrl: upstreamUrl.toString(),
+    upstreamParams: {
+      vendor_primary_hostname: vendorPrimaryHostname,
+      start_date: startDateIso,
+      end_date: endDateIso,
+    },
+    ...summary,
+  };
 }
 
 async function summarizeDebugResponse(response) {


### PR DESCRIPTION
### Motivation
- Ensure the UpGuard risk diff endpoint receives the required `vendor_primary_hostname`, `start_date`, and `end_date` query parameters instead of `hostname`, which was causing UpGuard to return the error `required param 'vendor_primary_hostname' missing`.

### Description
- Accept `vendor_primary_hostname` or `hostname` locally (with `vendor_primary_hostname` taking precedence) in ingestion routes via `getIngestionOptions` so local callers can use either parameter when triggering ingestion.
- Add `buildRiskDiffUrl(hostname, startDate, endDate)` to normalize and require a non-empty `vendor_primary_hostname` and to construct a URL that only sets `vendor_primary_hostname`, `start_date`, and `end_date` for UpGuard.
- Update `fetchRiskDiffResponse` to call `buildRiskDiffUrl` and send the resulting URL to UpGuard via `fetchUpGuard`, guaranteeing `vendor_primary_hostname` is present upstream.
- Update the debug route `GET /api/debug/upguard-risk-diff` to accept `vendor_primary_hostname` or `hostname`, compute ISO `start_date` and `end_date`, call UpGuard with `vendor_primary_hostname` (not `hostname`), and return `upstreamUrl` and `upstreamParams` for debugging.

### Testing
- Ran `node --check src/index.js` and it passed without syntax errors.
- Mocked and exercised `GET /api/debug/upguard-risk-diff?hostname=adobe.com&days=30` with a fake global `fetch` and validated the upstream request contains `vendor_primary_hostname=adobe.com` and does not include `hostname`, and the debug response includes `upstreamParams.vendor_primary_hostname`; this test passed.
- Mocked and exercised `GET /api/debug/upguard-risk-diff?vendor_primary_hostname=adobe.com&hostname=ignored.example&days=30` and validated `vendor_primary_hostname` takes precedence and `hostname` is not sent upstream; this test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00899821dc8332be1339ec3afdc2f6)