### PR TITLE
Fix UpGuard risk diff endpoint path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const PORTFOLIO_VENDORS = [
 const UPGUARD_DOMAIN_ENDPOINT = "https://cyber-risk.upguard.com/api/public/vendor/domain";
 const UPGUARD_PORTFOLIO_RISK_PROFILE_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risks/vendors/all";
 const UPGUARD_VENDOR_RISKS_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risks/vendors";
-const UPGUARD_RISK_DIFF_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risk/vendors/diff";
+const UPGUARD_RISK_DIFF_ENDPOINT = "https://cyber-risk.upguard.com/api/public/risks/vendors/diff";
 const DEFAULT_BATCH_SIZE = 6;
 const MAX_BATCH_SIZE = 10;
 const CURRENT_D1_TABLES = [
@@ -1024,6 +1024,7 @@ async function getDebugUpGuardRiskDiff(env, url) {
   const summary = await summarizeRiskDiffDebugResponse(response);
   return {
     requestedVendorPrimaryHostname,
+    upstreamEndpoint: upstreamUrl.origin + upstreamUrl.pathname,
     upstreamParams: {
       vendor_primary_hostname: requestedVendorPrimaryHostname,
       start_date: range.startDate,


### PR DESCRIPTION
### Motivation
- UpGuard risk-diff calls were returning HTTP 404 because the code used the wrong singular endpoint path (`/api/public/risk/vendors/diff`) instead of the correct plural path (`/api/public/risks/vendors/diff`).

### Description
- Replace `UPGUARD_RISK_DIFF_ENDPOINT` with the correct URL `https://cyber-risk.upguard.com/api/public/risks/vendors/diff` and include `upstreamEndpoint` in the `/api/debug/upguard-risk-diff` response while preserving the upstream params (`vendor_primary_hostname`, `start_date`, `end_date`, `include_sources`).

### Testing
- Ran `node --check src/index.js` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0090ab14008332af64c42b0116c6f9)